### PR TITLE
test: add /api/chat E2E validation

### DIFF
--- a/packages/backend/src/routes/chat.e2e.test.ts
+++ b/packages/backend/src/routes/chat.e2e.test.ts
@@ -15,13 +15,14 @@ function mkEnvelope(overrides: Record<string, unknown> = {}) {
   return { ...base, ...overrides };
 }
 
-async function postJson(path: string, body: unknown) {
+async function postJson(path: string, body: unknown): Promise<{ res: Response; json: any }> {
   const res = await app.request(path, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(body),
   });
-  const json = await res.json().catch(() => ({}));
+  // Response.json() is typed as unknown in this environment; for E2E assertions we treat it as any.
+  const json = (await res.json().catch(() => ({}))) as any;
   return { res, json };
 }
 


### PR DESCRIPTION
Adds an end-to-end (HTTP-level) test suite for the Conversation Interface (/api/chat):

- Enforces user-pain requirement: **pay.* is blocked until firewall approval** (fails closed)
- Verifies allowed state transitions
- Verifies idempotency replay behavior

This makes the spec enforceable on every PR via CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive end-to-end test suite for the chat API endpoint that validates multi-step state transitions, error handling for invalid transitions, firewall/payment checks, and idempotency (replayed messages flagged). These tests improve confidence in API behavior and prevent duplicate or invalid state changes during real-world message flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->