### PR TITLE
feat: Swagger UI + E2E test automation

### DIFF
--- a/docs/E2E_TEST_SCENARIOS.md
+++ b/docs/E2E_TEST_SCENARIOS.md
@@ -1,0 +1,360 @@
+# E2Eテストシナリオ
+
+ZeroKey Treasuryのエンドツーエンドテストシナリオ。
+
+---
+
+## シナリオ1: 正常なサービス購入フロー
+
+**ユースケース**: 企業AI秘書が信頼できるプロバイダから翻訳サービスを購入
+
+### ステップ1: プロバイダ検索
+
+**目的**: 翻訳サービスを提供するプロバイダを見つける
+
+**リクエスト**:
+```bash
+curl -s "http://localhost:3001/api/a2a/discover?service=translation"
+```
+
+**期待するレスポンス**:
+```json
+{
+  "success": true,
+  "results": [
+    {
+      "id": "translate-ai-001",
+      "name": "TranslateAI Pro",
+      "services": ["translation", "localization"],
+      "price": "0.03",
+      "unit": "1000 tokens",
+      "trustScore": 85,
+      "totalTransactions": 1250
+    }
+  ],
+  "count": 2
+}
+```
+
+**検証ポイント**:
+- [ ] `success` が `true`
+- [ ] `results` に1件以上のプロバイダ
+- [ ] TranslateAI Pro (trustScore >= 70) が含まれる
+
+---
+
+### ステップ2: 交渉セッション開始
+
+**目的**: 選んだプロバイダと交渉を開始
+
+**リクエスト**:
+```bash
+curl -s -X POST "http://localhost:3001/api/a2a/negotiate" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "clientId": "0x1234567890abcdef1234567890abcdef12345678",
+    "providerId": "translate-ai-001",
+    "service": "translation",
+    "initialOffer": "0.025"
+  }'
+```
+
+**期待するレスポンス**:
+```json
+{
+  "success": true,
+  "session": {
+    "id": "neg-1234567890-abc123",
+    "provider": "TranslateAI Pro",
+    "service": "translation",
+    "initialOffer": "0.025",
+    "providerPrice": "0.03",
+    "expiresAt": "2026-01-31T10:30:00.000Z"
+  }
+}
+```
+
+**検証ポイント**:
+- [ ] `success` が `true`
+- [ ] `session.id` が存在
+- [ ] `session.providerPrice` が "0.03"
+
+---
+
+### ステップ3: 価格交渉（オファー送信）
+
+**目的**: 価格を交渉して合意に達する
+
+**リクエスト**:
+```bash
+# SESSION_IDはステップ2のレスポンスから取得
+curl -s -X POST "http://localhost:3001/api/a2a/negotiate/${SESSION_ID}/offer" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": "0.028",
+    "type": "offer"
+  }'
+```
+
+**期待するレスポンス**:
+```json
+{
+  "success": true,
+  "status": "negotiating",
+  "response": {
+    "type": "accept",
+    "message": "Provider accepts 0.028 USDC"
+  }
+}
+```
+
+**検証ポイント**:
+- [ ] `success` が `true`
+- [ ] `response.type` が "accept" または "counter"
+- [ ] 90%以上のオファーは accept される
+
+---
+
+### ステップ4: Firewallチェック
+
+**目的**: 合意した取引がFirewallを通過するか確認
+
+**リクエスト**:
+```bash
+curl -s -X POST "http://localhost:3001/api/firewall/check" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "sessionId": "${SESSION_ID}"
+  }'
+```
+
+**期待するレスポンス**:
+```json
+{
+  "success": true,
+  "firewall": {
+    "decision": "APPROVED",
+    "riskLevel": 1,
+    "reason": "Trusted provider with good history",
+    "warnings": []
+  }
+}
+```
+
+**検証ポイント**:
+- [ ] `success` が `true`
+- [ ] `firewall.decision` が "APPROVED"
+- [ ] `firewall.riskLevel` が 1 または 2
+- [ ] `firewall.warnings` が空または軽微
+
+---
+
+### ステップ5: 決済（x402）
+
+**目的**: USDCで決済してサービスを利用
+
+**リクエスト (402レスポンス確認)**:
+```bash
+curl -s -X POST "http://localhost:3001/api/provider/translate" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "text": "hello",
+    "targetLanguage": "ja"
+  }'
+```
+
+**期待するレスポンス (402)**:
+```json
+{
+  "error": "Payment Required",
+  "code": 402,
+  "payment": {
+    "amount": "30000",
+    "recipient": "0x...",
+    "token": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+    "chainId": 84532
+  }
+}
+```
+
+**リクエスト (決済後)**:
+```bash
+curl -s -X POST "http://localhost:3001/api/provider/translate" \
+  -H "Content-Type: application/json" \
+  -H "X-Payment: 0xabc123...:84532:30000:0x1234..." \
+  -d '{
+    "text": "hello",
+    "targetLanguage": "ja"
+  }'
+```
+
+**期待するレスポンス (200)**:
+```json
+{
+  "success": true,
+  "service": "translation",
+  "result": {
+    "originalText": "hello",
+    "translatedText": "こんにちは",
+    "targetLanguage": "ja"
+  },
+  "payment": {
+    "txHash": "0xabc123...",
+    "amount": "0.03 USDC",
+    "status": "verified"
+  }
+}
+```
+
+**検証ポイント**:
+- [ ] 決済なし → 402ステータス
+- [ ] 決済あり → 200ステータス
+- [ ] 翻訳結果が返ってくる
+
+---
+
+## シナリオ2: 低信頼プロバイダのブロック
+
+**ユースケース**: Firewallが怪しいプロバイダをブロック
+
+### ステップ1: 低信頼プロバイダを検索
+
+```bash
+curl -s "http://localhost:3001/api/a2a/discover?service=translation"
+```
+
+**検証**: CheapTranslate (trustScore: 15) が含まれる
+
+---
+
+### ステップ2: 低信頼プロバイダと交渉開始
+
+```bash
+curl -s -X POST "http://localhost:3001/api/a2a/negotiate" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "clientId": "0x1234567890abcdef1234567890abcdef12345678",
+    "providerId": "sketchy-service-001",
+    "service": "translation",
+    "initialOffer": "0.005"
+  }'
+```
+
+---
+
+### ステップ3: Firewallチェック（警告/拒否）
+
+```bash
+curl -s -X POST "http://localhost:3001/api/firewall/check" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "sessionId": "${SESSION_ID}"
+  }'
+```
+
+**期待するレスポンス**:
+```json
+{
+  "success": true,
+  "firewall": {
+    "decision": "WARNING",
+    "riskLevel": 3,
+    "reason": "Low trust provider - proceed with caution",
+    "warnings": [
+      "Provider trust score is very low (15/100)",
+      "Price significantly below market average"
+    ]
+  }
+}
+```
+
+**検証ポイント**:
+- [ ] `firewall.decision` が "WARNING" または "REJECTED"
+- [ ] `firewall.riskLevel` が 3 (HIGH)
+- [ ] `firewall.warnings` に警告メッセージ
+
+---
+
+## シナリオ3: APIヘルスチェック
+
+### ヘルスエンドポイント
+
+```bash
+curl -s "http://localhost:3001/health"
+```
+
+**期待するレスポンス**:
+```json
+{
+  "status": "healthy",
+  "timestamp": "2026-01-31T09:00:00.000Z",
+  "version": "0.1.0"
+}
+```
+
+---
+
+## 手動テスト実行手順
+
+```bash
+# 1. バックエンド起動
+cd /home/exedev/HackMoney2026/packages/backend
+pnpm dev &
+sleep 5
+
+# 2. ヘルスチェック
+curl -s http://localhost:3001/health | jq .
+
+# 3. プロバイダ検索
+curl -s "http://localhost:3001/api/a2a/discover?service=translation" | jq .
+
+# 4. 交渉開始
+SESSION=$(curl -s -X POST "http://localhost:3001/api/a2a/negotiate" \
+  -H "Content-Type: application/json" \
+  -d '{"clientId": "0x123", "providerId": "translate-ai-001", "service": "translation", "initialOffer": "0.028"}' | jq -r '.session.id')
+echo "Session ID: $SESSION"
+
+# 5. オファー送信
+curl -s -X POST "http://localhost:3001/api/a2a/negotiate/${SESSION}/offer" \
+  -H "Content-Type: application/json" \
+  -d '{"amount": "0.028", "type": "accept"}' | jq .
+
+# 6. Firewallチェック
+curl -s -X POST "http://localhost:3001/api/firewall/check" \
+  -H "Content-Type: application/json" \
+  -d "{\"sessionId\": \"${SESSION}\"}" | jq .
+
+# 7. 402テスト
+curl -s -X POST "http://localhost:3001/api/provider/translate" \
+  -H "Content-Type: application/json" \
+  -d '{"text": "hello", "targetLanguage": "ja"}' | jq .
+
+# 8. 価格一覧
+curl -s "http://localhost:3001/api/provider/prices" | jq .
+```
+
+---
+
+## APIエンドポイント一覧
+
+| Method | Endpoint | 説明 | 認証 |
+|--------|----------|------|------|
+| GET | `/health` | ヘルスチェック | なし |
+| GET | `/api/a2a/discover?service=xxx` | プロバイダ検索 | なし |
+| GET | `/api/a2a/provider/:id` | プロバイダ詳細 | なし |
+| POST | `/api/a2a/negotiate` | 交渉開始 | なし |
+| POST | `/api/a2a/negotiate/:id/offer` | オファー送信 | なし |
+| GET | `/api/a2a/negotiate/:id` | セッション状態 | なし |
+| POST | `/api/firewall/check` | Firewallチェック | なし |
+| GET | `/api/firewall/status/:txHash` | ステータス取得 | なし |
+| GET | `/api/provider/prices` | 価格一覧 | なし |
+| POST | `/api/provider/translate` | 翻訳サービス | x402 |
+| POST | `/api/provider/summarize` | 要約サービス | x402 |
+
+---
+
+## 次のステップ
+
+1. [ ] Swagger/OpenAPI定義追加
+2. [ ] 自動化テストスクリプト作成
+3. [ ] CIで毎回E2Eテスト実行

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -18,12 +18,15 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.32.1",
     "@hono/node-server": "^1.13.7",
+    "@hono/swagger-ui": "^0.5.3",
+    "@hono/zod-openapi": "^1.2.0",
     "@hono/zod-validator": "^0.4.1",
     "@zerokey/shared": "workspace:*",
     "better-sqlite3": "^12.5.0",
     "dotenv": "^16.4.5",
     "drizzle-orm": "^0.45.1",
     "hono": "^4.6.10",
+    "hono-zod-openapi": "^1.0.2",
     "viem": "^2.21.40",
     "zod": "^3.23.8"
   },

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -9,6 +9,7 @@ import a2aRouter from "./routes/a2a.js";
 import { firewallRouter } from "./routes/firewall.js";
 import { chatRouter } from "./routes/chat.js";
 import providerRouter from "./routes/provider.js";
+import docsRouter from "./routes/openapi.js";
 import { config } from "./config.js";
 import { initializeDatabase } from "./db/index.js";
 
@@ -29,6 +30,7 @@ app.route("/api/a2a", a2aRouter);
 app.route("/api/firewall", firewallRouter);
 app.route("/api/chat", chatRouter);
 app.route("/api/provider", providerRouter);
+app.route("/docs", docsRouter);
 
 // Start server
 const port = config.port;

--- a/packages/backend/src/routes/openapi.ts
+++ b/packages/backend/src/routes/openapi.ts
@@ -1,0 +1,374 @@
+import { Hono } from "hono";
+import { swaggerUI } from "@hono/swagger-ui";
+
+const app = new Hono();
+
+// OpenAPI specification
+const openApiSpec = {
+  openapi: "3.0.0",
+  info: {
+    title: "ZeroKey Treasury API",
+    version: "0.1.0",
+    description: "AI Agent API Marketplace with Execution Firewall",
+  },
+  servers: [
+    {
+      url: "http://localhost:3001",
+      description: "Development server",
+    },
+  ],
+  paths: {
+    "/health": {
+      get: {
+        summary: "Health check",
+        tags: ["System"],
+        responses: {
+          "200": {
+            description: "Server is healthy",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    status: { type: "string", example: "healthy" },
+                    timestamp: { type: "string", format: "date-time" },
+                    version: { type: "string", example: "0.1.0" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/a2a/discover": {
+      get: {
+        summary: "Discover service providers",
+        tags: ["A2A Gateway"],
+        parameters: [
+          {
+            name: "service",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+            description: "Service type to search (e.g., translation, summarization)",
+            example: "translation",
+          },
+          {
+            name: "maxPrice",
+            in: "query",
+            required: false,
+            schema: { type: "string" },
+            description: "Maximum price in USDC",
+            example: "0.05",
+          },
+        ],
+        responses: {
+          "200": {
+            description: "List of matching providers",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean" },
+                    results: {
+                      type: "array",
+                      items: {
+                        type: "object",
+                        properties: {
+                          id: { type: "string" },
+                          name: { type: "string" },
+                          services: { type: "array", items: { type: "string" } },
+                          price: { type: "string" },
+                          unit: { type: "string" },
+                          trustScore: { type: "integer" },
+                          totalTransactions: { type: "integer" },
+                        },
+                      },
+                    },
+                    count: { type: "integer" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/a2a/provider/{id}": {
+      get: {
+        summary: "Get provider details",
+        tags: ["A2A Gateway"],
+        parameters: [
+          {
+            name: "id",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+            description: "Provider ID",
+          },
+        ],
+        responses: {
+          "200": {
+            description: "Provider details",
+          },
+          "404": {
+            description: "Provider not found",
+          },
+        },
+      },
+    },
+    "/api/a2a/negotiate": {
+      post: {
+        summary: "Start negotiation session",
+        tags: ["A2A Gateway"],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["clientId", "providerId", "service", "initialOffer"],
+                properties: {
+                  clientId: { type: "string", description: "Client wallet address" },
+                  providerId: { type: "string", description: "Provider ID" },
+                  service: { type: "string", description: "Service type" },
+                  initialOffer: { type: "string", description: "Initial offer in USDC" },
+                },
+              },
+              example: {
+                clientId: "0x1234567890abcdef1234567890abcdef12345678",
+                providerId: "translate-ai-001",
+                service: "translation",
+                initialOffer: "0.025",
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "Negotiation session created",
+          },
+        },
+      },
+    },
+    "/api/a2a/negotiate/{sessionId}/offer": {
+      post: {
+        summary: "Send offer in negotiation",
+        tags: ["A2A Gateway"],
+        parameters: [
+          {
+            name: "sessionId",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["amount", "type"],
+                properties: {
+                  amount: { type: "string", description: "Offer amount in USDC" },
+                  type: {
+                    type: "string",
+                    enum: ["offer", "counter", "accept", "reject"],
+                  },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "Offer response",
+          },
+        },
+      },
+    },
+    "/api/firewall/check": {
+      post: {
+        summary: "Check transaction with Firewall",
+        tags: ["Firewall"],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["sessionId"],
+                properties: {
+                  sessionId: { type: "string", description: "Negotiation session ID" },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "Firewall decision",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean" },
+                    firewall: {
+                      type: "object",
+                      properties: {
+                        decision: {
+                          type: "string",
+                          enum: ["APPROVED", "WARNING", "REJECTED"],
+                        },
+                        riskLevel: { type: "integer", minimum: 1, maximum: 3 },
+                        reason: { type: "string" },
+                        warnings: { type: "array", items: { type: "string" } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/provider/prices": {
+      get: {
+        summary: "Get service prices",
+        tags: ["Provider"],
+        responses: {
+          "200": {
+            description: "Service price list",
+          },
+        },
+      },
+    },
+    "/api/provider/translate": {
+      post: {
+        summary: "Translation service (requires x402 payment)",
+        tags: ["Provider"],
+        parameters: [
+          {
+            name: "X-Payment",
+            in: "header",
+            required: false,
+            schema: { type: "string" },
+            description: "Payment proof: txHash:chainId:amount:payer",
+          },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["text", "targetLanguage"],
+                properties: {
+                  text: { type: "string", description: "Text to translate" },
+                  targetLanguage: { type: "string", description: "Target language code" },
+                  sourceLanguage: { type: "string", description: "Source language code" },
+                },
+              },
+              example: {
+                text: "hello",
+                targetLanguage: "ja",
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "Translation result",
+          },
+          "402": {
+            description: "Payment required",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    error: { type: "string", example: "Payment Required" },
+                    code: { type: "integer", example: 402 },
+                    payment: {
+                      type: "object",
+                      properties: {
+                        amount: { type: "string" },
+                        recipient: { type: "string" },
+                        token: { type: "string" },
+                        chainId: { type: "integer" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/provider/summarize": {
+      post: {
+        summary: "Summarization service (requires x402 payment)",
+        tags: ["Provider"],
+        parameters: [
+          {
+            name: "X-Payment",
+            in: "header",
+            required: false,
+            schema: { type: "string" },
+            description: "Payment proof: txHash:chainId:amount:payer",
+          },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["text"],
+                properties: {
+                  text: { type: "string", description: "Text to summarize" },
+                  maxLength: { type: "integer", description: "Maximum summary length" },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "Summarization result",
+          },
+          "402": {
+            description: "Payment required",
+          },
+        },
+      },
+    },
+  },
+  tags: [
+    { name: "System", description: "System endpoints" },
+    { name: "A2A Gateway", description: "Agent-to-Agent service discovery and negotiation" },
+    { name: "Firewall", description: "Execution firewall and risk analysis" },
+    { name: "Provider", description: "Mock service provider endpoints (x402 payment)" },
+  ],
+};
+
+// Serve OpenAPI spec as JSON
+app.get("/openapi.json", (c) => {
+  return c.json(openApiSpec);
+});
+
+// Serve Swagger UI
+app.get(
+  "/",
+  swaggerUI({
+    url: "/docs/openapi.json",
+  })
+);
+
+export default app;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,12 @@ importers:
       '@hono/node-server':
         specifier: ^1.13.7
         version: 1.19.9(hono@4.11.7)
+      '@hono/swagger-ui':
+        specifier: ^0.5.3
+        version: 0.5.3(hono@4.11.7)
+      '@hono/zod-openapi':
+        specifier: ^1.2.0
+        version: 1.2.0(hono@4.11.7)(zod@3.25.76)
       '@hono/zod-validator':
         specifier: ^0.4.1
         version: 0.4.3(hono@4.11.7)(zod@3.25.76)
@@ -65,6 +71,9 @@ importers:
       hono:
         specifier: ^4.6.10
         version: 4.11.7
+      hono-zod-openapi:
+        specifier: ^1.0.2
+        version: 1.0.2(hono@4.11.7)(zod@3.25.76)
       viem:
         specifier: ^2.21.40
         version: 2.45.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -173,6 +182,11 @@ packages:
 
   '@anthropic-ai/sdk@0.32.1':
     resolution: {integrity: sha512-U9JwTrDvdQ9iWuABVsMLj8nJVwAyQz6QXvgLsVhryhCEPkLsbcP/MXxm+jYcAwLoV8ESbaTTjnD4kuAFa+Hyjg==}
+
+  '@asteasolutions/zod-to-openapi@8.4.0':
+    resolution: {integrity: sha512-Ckp971tmTw4pnv+o7iK85ldBHBKk6gxMaoNyLn3c2Th/fKoTG8G3jdYuOanpdGqwlDB0z01FOjry2d32lfTqrA==}
+    peerDependencies:
+      zod: ^4.0.0
 
   '@babel/code-frame@7.28.6':
     resolution: {integrity: sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==}
@@ -874,11 +888,29 @@ packages:
     peerDependencies:
       hono: ^4
 
+  '@hono/swagger-ui@0.5.3':
+    resolution: {integrity: sha512-Hn90DOOJ62ICJQplQvCDVpi9Jcn6EhtRaiffyJIS53wA5RmRLtMCDQGVc0bor8vQD7JIwpkweWjs+3cycp+IvA==}
+    peerDependencies:
+      hono: '>=4.0.0'
+
+  '@hono/zod-openapi@1.2.0':
+    resolution: {integrity: sha512-KDfHqv/Wy4elVseZXgokbHxeWuqBL+AZfqsOMpEihBMUsk/fJ+bLIi3Sf70JFVpt1Ihui8RasYrInozt7ZBDIA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      hono: '>=4.3.6'
+      zod: ^4.0.0
+
   '@hono/zod-validator@0.4.3':
     resolution: {integrity: sha512-xIgMYXDyJ4Hj6ekm9T9Y27s080Nl9NXHcJkOvkXPhubOLj8hZkOL8pDnnXfvCf5xEE8Q4oMFenQUZZREUY2gqQ==}
     peerDependencies:
       hono: '>=3.9.0'
       zod: ^3.19.1
+
+  '@hono/zod-validator@0.7.6':
+    resolution: {integrity: sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw==}
+    peerDependencies:
+      hono: '>=3.9.0'
+      zod: ^3.25.0 || ^4.0.0
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -3499,6 +3531,13 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hono-zod-openapi@1.0.2:
+    resolution: {integrity: sha512-LIjv7V3WuKMdm112s1uHwPilaGETgCjvTRSmgcYF4BZToVsWpotE16Bp1lggVYZjwFWbpUwlGGJzFv3Y/W1xNg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4.8.0
+      zod: ^4.0.0
+
   hono@4.11.7:
     resolution: {integrity: sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==}
     engines: {node: '>=16.9.0'}
@@ -4120,6 +4159,9 @@ packages:
 
   openapi-typescript-helpers@0.0.15:
     resolution: {integrity: sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==}
+
+  openapi3-ts@4.5.0:
+    resolution: {integrity: sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -5353,6 +5395,12 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod-openapi@5.4.6:
+    resolution: {integrity: sha512-P2jsOOBAq/6hCwUsMCjUATZ8szkMsV5VAwZENfyxp2Hc/XPJQpVwAgevWZc65xZauCwWB9LAn7zYeiCJFAEL+A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      zod: ^3.25.74 || ^4.0.0
+
   zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
 
@@ -5433,6 +5481,11 @@ snapshots:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
+
+  '@asteasolutions/zod-to-openapi@8.4.0(zod@3.25.76)':
+    dependencies:
+      openapi3-ts: 4.5.0
+      zod: 3.25.76
 
   '@babel/code-frame@7.28.6':
     dependencies:
@@ -5927,7 +5980,24 @@ snapshots:
     dependencies:
       hono: 4.11.7
 
+  '@hono/swagger-ui@0.5.3(hono@4.11.7)':
+    dependencies:
+      hono: 4.11.7
+
+  '@hono/zod-openapi@1.2.0(hono@4.11.7)(zod@3.25.76)':
+    dependencies:
+      '@asteasolutions/zod-to-openapi': 8.4.0(zod@3.25.76)
+      '@hono/zod-validator': 0.7.6(hono@4.11.7)(zod@3.25.76)
+      hono: 4.11.7
+      openapi3-ts: 4.5.0
+      zod: 3.25.76
+
   '@hono/zod-validator@0.4.3(hono@4.11.7)(zod@3.25.76)':
+    dependencies:
+      hono: 4.11.7
+      zod: 3.25.76
+
+  '@hono/zod-validator@0.7.6(hono@4.11.7)(zod@3.25.76)':
     dependencies:
       hono: 4.11.7
       zod: 3.25.76
@@ -9534,6 +9604,13 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hono-zod-openapi@1.0.2(hono@4.11.7)(zod@3.25.76):
+    dependencies:
+      '@hono/zod-validator': 0.7.6(hono@4.11.7)(zod@3.25.76)
+      hono: 4.11.7
+      zod: 3.25.76
+      zod-openapi: 5.4.6(zod@3.25.76)
+
   hono@4.11.7: {}
 
   http-cache-semantics@4.2.0: {}
@@ -10133,6 +10210,10 @@ snapshots:
       openapi-typescript-helpers: 0.0.15
 
   openapi-typescript-helpers@0.0.15: {}
+
+  openapi3-ts@4.5.0:
+    dependencies:
+      yaml: 2.8.2
 
   optionator@0.9.4:
     dependencies:
@@ -11567,6 +11648,10 @@ snapshots:
       yargs-parser: 18.1.3
 
   yocto-queue@0.1.0: {}
+
+  zod-openapi@5.4.6(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.22.4: {}
 

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+# ZeroKey Treasury E2E Test Script
+# Run: ./scripts/e2e-test.sh
+
+# Don't use set -e because we handle errors manually
+
+API_URL="${API_URL:-http://localhost:3001}"
+PASSED=0
+FAILED=0
+
+echo "========================================"
+echo "ZeroKey Treasury E2E Tests"
+echo "API: $API_URL"
+echo "========================================"
+echo ""
+
+# Helper functions
+pass() {
+  echo "✅ PASS: $1"
+  ((PASSED++))
+}
+
+fail() {
+  echo "❌ FAIL: $1"
+  echo "   Expected: $2"
+  echo "   Got: $3"
+  ((FAILED++))
+}
+
+test_json() {
+  local name="$1"
+  local response="$2"
+  local jq_filter="$3"
+  local expected="$4"
+  
+  local actual=$(echo "$response" | jq -r "$jq_filter" 2>/dev/null)
+  
+  if [ "$actual" == "$expected" ]; then
+    pass "$name"
+  else
+    fail "$name" "$expected" "$actual"
+  fi
+}
+
+test_contains() {
+  local name="$1"
+  local response="$2"
+  local pattern="$3"
+  
+  if [[ "$response" == *"$pattern"* ]]; then
+    pass "$name"
+  else
+    fail "$name" "contains '$pattern'" "not found"
+  fi
+}
+
+test_status() {
+  local name="$1"
+  local status="$2"
+  local expected="$3"
+  
+  if [ "$status" == "$expected" ]; then
+    pass "$name"
+  else
+    fail "$name" "HTTP $expected" "HTTP $status"
+  fi
+}
+
+echo "=== Scenario 1: Health Check ==="
+RESPONSE=$(curl -s "$API_URL/health")
+test_json "Health status is healthy" "$RESPONSE" ".status" "healthy"
+test_contains "Health has version" "$RESPONSE" "version"
+echo ""
+
+echo "=== Scenario 2: Provider Discovery ==="
+RESPONSE=$(curl -s "$API_URL/api/a2a/discover?service=translation")
+test_json "Discovery success" "$RESPONSE" ".success" "true"
+test_json "Has results" "$RESPONSE" '.results | length > 0' "true"
+test_contains "Has TranslateAI Pro" "$RESPONSE" "TranslateAI Pro"
+test_contains "Has CheapTranslate" "$RESPONSE" "CheapTranslate"
+echo ""
+
+echo "=== Scenario 3: Provider Details ==="
+RESPONSE=$(curl -s "$API_URL/api/a2a/provider/translate-ai-001")
+test_json "Provider lookup success" "$RESPONSE" ".success" "true"
+test_json "Provider trust score >= 70" "$RESPONSE" '.provider.trustScore >= 70' "true"
+echo ""
+
+echo "=== Scenario 4: Start Negotiation ==="
+RESPONSE=$(curl -s -X POST "$API_URL/api/a2a/negotiate" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "clientId": "0x1234567890abcdef1234567890abcdef12345678",
+    "providerId": "translate-ai-001",
+    "service": "translation",
+    "initialOffer": "0.028"
+  }')
+test_json "Negotiation start success" "$RESPONSE" ".success" "true"
+SESSION_ID=$(echo "$RESPONSE" | jq -r '.session.id')
+if [ "$SESSION_ID" != "null" ] && [ -n "$SESSION_ID" ]; then
+  pass "Session ID returned: $SESSION_ID"
+else
+  fail "Session ID returned" "valid id" "null"
+fi
+echo ""
+
+echo "=== Scenario 5: Send Offer ==="
+if [ "$SESSION_ID" != "null" ] && [ -n "$SESSION_ID" ]; then
+  RESPONSE=$(curl -s -X POST "$API_URL/api/a2a/negotiate/$SESSION_ID/offer" \
+    -H "Content-Type: application/json" \
+    -d '{"amount": "0.028", "type": "offer"}')
+  test_json "Offer success" "$RESPONSE" ".success" "true"
+  # 0.028 >= 0.03 * 0.9 = 0.027, so should be accepted
+  test_json "Offer accepted" "$RESPONSE" ".response.type" "accept"
+else
+  fail "Send Offer" "valid session" "no session"
+fi
+echo ""
+
+echo "=== Scenario 6: x402 Payment Required ==="
+RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$API_URL/api/provider/translate" \
+  -H "Content-Type: application/json" \
+  -d '{"text": "hello", "targetLanguage": "ja"}')
+BODY=$(echo "$RESPONSE" | head -n -1)
+STATUS=$(echo "$RESPONSE" | tail -n 1)
+test_status "No payment returns 402" "$STATUS" "402"
+test_contains "Has payment info" "$BODY" "Payment Required"
+test_contains "Has USDC token address" "$BODY" "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+echo ""
+
+echo "=== Scenario 7: Provider Prices ==="
+RESPONSE=$(curl -s "$API_URL/api/provider/prices")
+test_contains "Has translation service" "$RESPONSE" "translation"
+test_contains "Has summarization service" "$RESPONSE" "summarization"
+test_contains "Has USDC" "$RESPONSE" "USDC"
+echo ""
+
+echo "=== Scenario 8: Low Trust Provider Warning ==="
+RESPONSE=$(curl -s -X POST "$API_URL/api/a2a/negotiate" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "clientId": "0x1234567890abcdef1234567890abcdef12345678",
+    "providerId": "sketchy-service-001",
+    "service": "translation",
+    "initialOffer": "0.005"
+  }')
+test_json "Low trust negotiation success" "$RESPONSE" ".success" "true"
+SKETCHY_SESSION=$(echo "$RESPONSE" | jq -r '.session.id')
+if [ "$SKETCHY_SESSION" != "null" ] && [ -n "$SKETCHY_SESSION" ]; then
+  pass "Sketchy session created"
+else
+  fail "Sketchy session" "valid id" "null"
+fi
+echo ""
+
+echo "========================================"
+echo "Results: $PASSED passed, $FAILED failed"
+echo "========================================"
+
+if [ $FAILED -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 概要
API ドキュメントと自動E2Eテストを追加。

## 追加機能

### Swagger UI
- `/docs` でSwagger UIにアクセス
- 全エンドポイントのドキュメント
- Try it out機能で直接API実行可能

### E2Eテストシナリオ
`docs/E2E_TEST_SCENARIOS.md`:
- シナリオ1: 正常なサービス購入フロー
- シナリオ2: 低信頼プロバイダのブロック
- シナリオ3: ヘルスチェック

### 自動テストスクリプト
`scripts/e2e-test.sh`:
- 20のテストケース
- 全テストパス

## テスト実行
```bash
# バックエンド起動
cd packages/backend && pnpm dev

# E2Eテスト実行
./scripts/e2e-test.sh
```

## Swagger UI
http://localhost:3001/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Interactive API documentation now available at the /docs endpoint with complete OpenAPI specification browser and Swagger UI for exploring all available API operations and schemas.

* **Documentation**
  * Added comprehensive end-to-end testing scenarios guide covering normal service flows, firewall provider blocking, payment handling with 402 status, health checks, and detailed manual test execution steps with curl examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->