### PR TITLE
feat: Nginx reverse proxy for single-port access

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,72 @@
+# ZeroKey Treasury - Reverse Proxy Configuration
+# Single port (8000) for both frontend and backend API
+
+worker_processes 1;
+error_log /tmp/nginx-error.log;
+pid /tmp/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+    access_log /tmp/nginx-access.log;
+    
+    # Temp paths for non-root
+    client_body_temp_path /tmp/nginx-client-body;
+    proxy_temp_path /tmp/nginx-proxy;
+    fastcgi_temp_path /tmp/nginx-fastcgi;
+    uwsgi_temp_path /tmp/nginx-uwsgi;
+    scgi_temp_path /tmp/nginx-scgi;
+
+    server {
+        listen 8000;
+        server_name localhost;
+
+        # API routes -> Backend (port 3001)
+        location /api/ {
+            proxy_pass http://127.0.0.1:3001;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Health endpoint -> Backend
+        location /health {
+            proxy_pass http://127.0.0.1:3001;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+        }
+
+        # Swagger docs -> Backend
+        location /docs {
+            proxy_pass http://127.0.0.1:3001;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+        }
+
+        # Everything else -> Frontend (port 3000)
+        location / {
+            proxy_pass http://127.0.0.1:3000;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+
+        # Next.js HMR WebSocket
+        location /_next/webpack-hmr {
+            proxy_pass http://127.0.0.1:3000;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+    }
+}

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Start ZeroKey Treasury development environment
+# Access at http://localhost:8000 or https://zerokey.exe.xyz:8000
+
+set -e
+
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$PROJECT_DIR"
+
+echo "========================================"
+echo "ZeroKey Treasury - Development Server"
+echo "========================================"
+echo ""
+
+# Kill existing processes
+echo "Cleaning up existing processes..."
+pkill -f "tsx watch" 2>/dev/null || true
+pkill -f "next dev" 2>/dev/null || true
+pkill -f "nginx.*nginx.conf" 2>/dev/null || true
+sleep 2
+
+# Create temp directories for nginx
+mkdir -p /tmp/nginx-client-body /tmp/nginx-proxy /tmp/nginx-fastcgi /tmp/nginx-uwsgi /tmp/nginx-scgi
+
+# Start backend (port 3001)
+echo "Starting backend on port 3001..."
+cd "$PROJECT_DIR/packages/backend"
+pnpm dev > /tmp/zerokey-backend.log 2>&1 &
+BACKEND_PID=$!
+echo "Backend PID: $BACKEND_PID"
+
+# Wait for backend
+sleep 5
+if curl -s http://localhost:3001/health > /dev/null; then
+  echo "✅ Backend is running"
+else
+  echo "❌ Backend failed to start"
+  cat /tmp/zerokey-backend.log
+  exit 1
+fi
+
+# Start frontend (port 3000)
+echo "Starting frontend on port 3000..."
+cd "$PROJECT_DIR/packages/frontend"
+PORT=3000 pnpm dev > /tmp/zerokey-frontend.log 2>&1 &
+FRONTEND_PID=$!
+echo "Frontend PID: $FRONTEND_PID"
+
+# Wait for frontend
+sleep 10
+if curl -s http://localhost:3000 > /dev/null; then
+  echo "✅ Frontend is running"
+else
+  echo "⚠️ Frontend may still be starting..."
+fi
+
+# Start nginx reverse proxy (port 8000)
+echo "Starting nginx reverse proxy on port 8000..."
+nginx -c "$PROJECT_DIR/nginx.conf" -g 'daemon off;' > /tmp/zerokey-nginx.log 2>&1 &
+NGINX_PID=$!
+echo "Nginx PID: $NGINX_PID"
+
+sleep 2
+if curl -s http://localhost:8000/health > /dev/null; then
+  echo "✅ Reverse proxy is running"
+else
+  echo "❌ Reverse proxy failed"
+  cat /tmp/zerokey-nginx.log
+fi
+
+echo ""
+echo "========================================"
+echo "ZeroKey Treasury is running!"
+echo "========================================"
+echo ""
+echo "Access URLs:"
+echo "  Local:    http://localhost:8000"
+echo "  Public:   https://zerokey.exe.xyz:8000"
+echo ""
+echo "Endpoints:"
+echo "  Frontend:  http://localhost:8000/"
+echo "  API:       http://localhost:8000/api/"
+echo "  Swagger:   http://localhost:8000/docs"
+echo "  Health:    http://localhost:8000/health"
+echo ""
+echo "Logs:"
+echo "  Backend:   /tmp/zerokey-backend.log"
+echo "  Frontend:  /tmp/zerokey-frontend.log"
+echo "  Nginx:     /tmp/zerokey-nginx.log"
+echo ""
+echo "Press Ctrl+C to stop all services"
+echo ""
+
+# Wait and handle shutdown
+trap "echo 'Shutting down...'; kill $BACKEND_PID $FRONTEND_PID $NGINX_PID 2>/dev/null; exit 0" SIGINT SIGTERM
+
+wait


### PR DESCRIPTION
## 概要
単一ポート(8000)でフロントエンドとバックエンドの両方にアクセス可能にするリバースプロキシを追加。

## ルーティング
| パス | 転送先 |
|------|--------|
| /api/* | Backend (3001) |
| /health | Backend (3001) |
| /docs | Backend (3001) |
| /* | Frontend (3000) |

## 使い方
```bash
./scripts/start-dev.sh
```

## アクセスURL
- ローカル: http://localhost:8000
- 公開: https://zerokey.exe.xyz:8000

## エンドポイント
- Frontend: http://localhost:8000/
- Marketplace: http://localhost:8000/marketplace
- API: http://localhost:8000/api/a2a/discover?service=translation
- Swagger: http://localhost:8000/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added reverse proxy configuration to route API, health, docs, and WebSocket traffic to appropriate backend and frontend services on development port 8000
  * Added development startup script to manage backend, frontend, and reverse proxy processes with health checks, status reporting, and graceful shutdown handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->