### PR TITLE
docs: add A2A/Firewall auth spec

### DIFF
--- a/docs/E2E_TEST_SCENARIOS.md
+++ b/docs/E2E_TEST_SCENARIOS.md
@@ -13,11 +13,13 @@ ZeroKey Treasuryのエンドツーエンドテストシナリオ。
 **目的**: 翻訳サービスを提供するプロバイダを見つける
 
 **リクエスト**:
+
 ```bash
 curl -s "http://localhost:3001/api/a2a/discover?service=translation"
 ```
 
 **期待するレスポンス**:
+
 ```json
 {
   "success": true,
@@ -37,6 +39,7 @@ curl -s "http://localhost:3001/api/a2a/discover?service=translation"
 ```
 
 **検証ポイント**:
+
 - [ ] `success` が `true`
 - [ ] `results` に1件以上のプロバイダ
 - [ ] TranslateAI Pro (trustScore >= 70) が含まれる
@@ -48,6 +51,7 @@ curl -s "http://localhost:3001/api/a2a/discover?service=translation"
 **目的**: 選んだプロバイダと交渉を開始
 
 **リクエスト**:
+
 ```bash
 curl -s -X POST "http://localhost:3001/api/a2a/negotiate" \
   -H "Content-Type: application/json" \
@@ -60,6 +64,7 @@ curl -s -X POST "http://localhost:3001/api/a2a/negotiate" \
 ```
 
 **期待するレスポンス**:
+
 ```json
 {
   "success": true,
@@ -75,6 +80,7 @@ curl -s -X POST "http://localhost:3001/api/a2a/negotiate" \
 ```
 
 **検証ポイント**:
+
 - [ ] `success` が `true`
 - [ ] `session.id` が存在
 - [ ] `session.providerPrice` が "0.03"
@@ -86,6 +92,7 @@ curl -s -X POST "http://localhost:3001/api/a2a/negotiate" \
 **目的**: 価格を交渉して合意に達する
 
 **リクエスト**:
+
 ```bash
 # SESSION_IDはステップ2のレスポンスから取得
 curl -s -X POST "http://localhost:3001/api/a2a/negotiate/${SESSION_ID}/offer" \
@@ -97,6 +104,7 @@ curl -s -X POST "http://localhost:3001/api/a2a/negotiate/${SESSION_ID}/offer" \
 ```
 
 **期待するレスポンス**:
+
 ```json
 {
   "success": true,
@@ -109,6 +117,7 @@ curl -s -X POST "http://localhost:3001/api/a2a/negotiate/${SESSION_ID}/offer" \
 ```
 
 **検証ポイント**:
+
 - [ ] `success` が `true`
 - [ ] `response.type` が "accept" または "counter"
 - [ ] 90%以上のオファーは accept される
@@ -120,6 +129,7 @@ curl -s -X POST "http://localhost:3001/api/a2a/negotiate/${SESSION_ID}/offer" \
 **目的**: 合意した取引がFirewallを通過するか確認
 
 **リクエスト**:
+
 ```bash
 curl -s -X POST "http://localhost:3001/api/firewall/check" \
   -H "Content-Type: application/json" \
@@ -129,6 +139,7 @@ curl -s -X POST "http://localhost:3001/api/firewall/check" \
 ```
 
 **期待するレスポンス**:
+
 ```json
 {
   "success": true,
@@ -142,6 +153,7 @@ curl -s -X POST "http://localhost:3001/api/firewall/check" \
 ```
 
 **検証ポイント**:
+
 - [ ] `success` が `true`
 - [ ] `firewall.decision` が "APPROVED"
 - [ ] `firewall.riskLevel` が 1 または 2
@@ -154,6 +166,7 @@ curl -s -X POST "http://localhost:3001/api/firewall/check" \
 **目的**: USDCで決済してサービスを利用
 
 **リクエスト (402レスポンス確認)**:
+
 ```bash
 curl -s -X POST "http://localhost:3001/api/provider/translate" \
   -H "Content-Type: application/json" \
@@ -164,6 +177,7 @@ curl -s -X POST "http://localhost:3001/api/provider/translate" \
 ```
 
 **期待するレスポンス (402)**:
+
 ```json
 {
   "error": "Payment Required",
@@ -178,6 +192,7 @@ curl -s -X POST "http://localhost:3001/api/provider/translate" \
 ```
 
 **リクエスト (決済後)**:
+
 ```bash
 curl -s -X POST "http://localhost:3001/api/provider/translate" \
   -H "Content-Type: application/json" \
@@ -189,6 +204,7 @@ curl -s -X POST "http://localhost:3001/api/provider/translate" \
 ```
 
 **期待するレスポンス (200)**:
+
 ```json
 {
   "success": true,
@@ -207,6 +223,7 @@ curl -s -X POST "http://localhost:3001/api/provider/translate" \
 ```
 
 **検証ポイント**:
+
 - [ ] 決済なし → 402ステータス
 - [ ] 決済あり → 200ステータス
 - [ ] 翻訳結果が返ってくる
@@ -253,6 +270,7 @@ curl -s -X POST "http://localhost:3001/api/firewall/check" \
 ```
 
 **期待するレスポンス**:
+
 ```json
 {
   "success": true,
@@ -269,6 +287,7 @@ curl -s -X POST "http://localhost:3001/api/firewall/check" \
 ```
 
 **検証ポイント**:
+
 - [ ] `firewall.decision` が "WARNING" または "REJECTED"
 - [ ] `firewall.riskLevel` が 3 (HIGH)
 - [ ] `firewall.warnings` に警告メッセージ
@@ -284,6 +303,7 @@ curl -s "http://localhost:3001/health"
 ```
 
 **期待するレスポンス**:
+
 ```json
 {
   "status": "healthy",
@@ -337,19 +357,19 @@ curl -s "http://localhost:3001/api/provider/prices" | jq .
 
 ## APIエンドポイント一覧
 
-| Method | Endpoint | 説明 | 認証 |
-|--------|----------|------|------|
-| GET | `/health` | ヘルスチェック | なし |
-| GET | `/api/a2a/discover?service=xxx` | プロバイダ検索 | なし |
-| GET | `/api/a2a/provider/:id` | プロバイダ詳細 | なし |
-| POST | `/api/a2a/negotiate` | 交渉開始 | なし |
-| POST | `/api/a2a/negotiate/:id/offer` | オファー送信 | なし |
-| GET | `/api/a2a/negotiate/:id` | セッション状態 | なし |
-| POST | `/api/firewall/check` | Firewallチェック | なし |
-| GET | `/api/firewall/status/:txHash` | ステータス取得 | なし |
-| GET | `/api/provider/prices` | 価格一覧 | なし |
-| POST | `/api/provider/translate` | 翻訳サービス | x402 |
-| POST | `/api/provider/summarize` | 要約サービス | x402 |
+| Method | Endpoint                        | 説明             | 認証 |
+| ------ | ------------------------------- | ---------------- | ---- |
+| GET    | `/health`                       | ヘルスチェック   | なし |
+| GET    | `/api/a2a/discover?service=xxx` | プロバイダ検索   | なし |
+| GET    | `/api/a2a/provider/:id`         | プロバイダ詳細   | なし |
+| POST   | `/api/a2a/negotiate`            | 交渉開始         | なし |
+| POST   | `/api/a2a/negotiate/:id/offer`  | オファー送信     | なし |
+| GET    | `/api/a2a/negotiate/:id`        | セッション状態   | なし |
+| POST   | `/api/firewall/check`           | Firewallチェック | なし |
+| GET    | `/api/firewall/status/:txHash`  | ステータス取得   | なし |
+| GET    | `/api/provider/prices`          | 価格一覧         | なし |
+| POST   | `/api/provider/translate`       | 翻訳サービス     | x402 |
+| POST   | `/api/provider/summarize`       | 要約サービス     | x402 |
 
 ---
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -109,6 +109,7 @@ pnpm -C packages/backend build
    - `GET /api/provider/prices` - 価格一覧
 
 **テスト:**
+
 ```bash
 # 価格確認
 curl http://localhost:3001/api/provider/prices
@@ -145,6 +146,7 @@ curl -X POST http://localhost:3001/api/provider/translate \
    - ウォレット接続統合
 
 **テスト:**
+
 ```bash
 cd packages/frontend && pnpm dev
 # http://localhost:3000/marketplace

--- a/docs/a2a-firewall.md
+++ b/docs/a2a-firewall.md
@@ -50,7 +50,6 @@ To avoid cross-implementation mismatches, this spec fixes base64 variants as fol
 - Unless explicitly stated otherwise, **Base64** means **RFC 4648 standard Base64** with `+` and `/`, and with `=` padding.
 - Applies to: `X-Nonce`, `Signature.signature`, and all `base64(...)` values shown in this document.
 
-
 ### 3.1 Requests with a body (POST/PUT/PATCH)
 
 Required:

--- a/packages/backend/src/routes/provider.ts
+++ b/packages/backend/src/routes/provider.ts
@@ -13,12 +13,15 @@ import type { Address } from "viem";
 const app = new Hono();
 
 // Provider wallet (for receiving payments)
-const PROVIDER_WALLET = (process.env.PROVIDER_WALLET_ADDRESS || "0x0000000000000000000000000000000000000000") as Address;
+const PROVIDER_WALLET = (process.env.PROVIDER_WALLET_ADDRESS ||
+  "0x0000000000000000000000000000000000000000") as Address;
 
 /**
  * Helper to get payment from header
  */
-function getPaymentFromHeader(c: { req: { header: (name: string) => string | undefined } }): PaymentProof | null {
+function getPaymentFromHeader(c: {
+  req: { header: (name: string) => string | undefined };
+}): PaymentProof | null {
   const header = c.req.header("X-Payment");
   if (!header) return null;
   return parsePaymentHeader(header);
@@ -41,19 +44,13 @@ app.post(
   async (c) => {
     const { text, targetLanguage, sourceLanguage } = c.req.valid("json");
     const payment = getPaymentFromHeader(c);
-    
+
     if (!payment) {
       return c.json({ error: "Payment not found" }, 400);
     }
 
     // Record the payment
-    recordPayment(
-      payment.txHash,
-      payment.payer,
-      PROVIDER_WALLET,
-      "0.03",
-      "translation"
-    );
+    recordPayment(payment.txHash, payment.payer, PROVIDER_WALLET, "0.03", "translation");
 
     // Mock translation (in production, call actual translation API)
     const translations: Record<string, Record<string, string>> = {
@@ -82,7 +79,8 @@ app.post(
 
     const lowerText = text.toLowerCase();
     const langTranslations = translations[targetLanguage] ?? translations.en ?? {};
-    const translatedText = langTranslations[lowerText] ?? `[Translated to ${targetLanguage}]: ${text}`;
+    const translatedText =
+      langTranslations[lowerText] ?? `[Translated to ${targetLanguage}]: ${text}`;
 
     return c.json({
       success: true,
@@ -117,25 +115,17 @@ app.post(
   async (c) => {
     const { text, maxLength } = c.req.valid("json");
     const payment = getPaymentFromHeader(c);
-    
+
     if (!payment) {
       return c.json({ error: "Payment not found" }, 400);
     }
 
     // Record the payment
-    recordPayment(
-      payment.txHash,
-      payment.payer,
-      PROVIDER_WALLET,
-      "0.02",
-      "summarization"
-    );
+    recordPayment(payment.txHash, payment.payer, PROVIDER_WALLET, "0.02", "summarization");
 
     // Mock summarization
     const words = text.split(/\s+/);
-    const summary = words.length > 20
-      ? words.slice(0, 20).join(" ") + "..."
-      : text;
+    const summary = words.length > 20 ? words.slice(0, 20).join(" ") + "..." : text;
 
     return c.json({
       success: true,

--- a/packages/backend/src/services/payment.ts
+++ b/packages/backend/src/services/payment.ts
@@ -11,7 +11,8 @@ const USDC_ADDRESS = "0x036CbD53842c5426634e7929541eC2318f3dCF7e" as Address;
 const USDC_DECIMALS = 6;
 
 // ERC20 Transfer event signature
-const TRANSFER_EVENT_SIGNATURE = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const TRANSFER_EVENT_SIGNATURE =
+  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 
 export interface PaymentRecord {
   txHash: Hex;
@@ -44,7 +45,7 @@ export async function verifyUsdcTransfer(
 
     // Get transaction receipt
     const receipt = await client.getTransactionReceipt({ hash: txHash });
-    
+
     if (!receipt) {
       return { valid: false, reason: "Transaction not found or not confirmed" };
     }
@@ -158,7 +159,7 @@ export function getTotalSpent(payer: Address, sinceTimestamp?: number): number {
   const filtered = sinceTimestamp
     ? payments.filter((p) => p.timestamp >= sinceTimestamp)
     : payments;
-  
+
   return filtered.reduce((sum, p) => sum + parseFloat(p.amountUsdc), 0);
 }
 

--- a/packages/frontend/src/app/marketplace/page.tsx
+++ b/packages/frontend/src/app/marketplace/page.tsx
@@ -83,10 +83,7 @@ export default function MarketplacePage() {
           >
             Dashboard
           </Link>
-          <Link
-            href="/marketplace"
-            className="text-sm font-medium text-primary-400"
-          >
+          <Link href="/marketplace" className="text-sm font-medium text-primary-400">
             Marketplace
           </Link>
           <ConnectButton />
@@ -178,9 +175,7 @@ function ProviderCard({
 
       <div className="flex justify-between items-center mb-4 text-sm">
         <span className="text-gray-400">Trust Score</span>
-        <span className={getTrustColor(provider.trustScore)}>
-          {provider.trustScore}/100
-        </span>
+        <span className={getTrustColor(provider.trustScore)}>{provider.trustScore}/100</span>
       </div>
 
       <div className="flex justify-between items-center mb-4 text-sm">
@@ -189,9 +184,7 @@ function ProviderCard({
       </div>
 
       <div className="flex justify-between items-center mb-6">
-        <span className="text-2xl font-bold text-primary-400">
-          ${provider.price}
-        </span>
+        <span className="text-2xl font-bold text-primary-400">${provider.price}</span>
         <span className="text-gray-400 text-sm">/{provider.unit}</span>
       </div>
 

--- a/packages/frontend/src/app/negotiate/[providerId]/page.tsx
+++ b/packages/frontend/src/app/negotiate/[providerId]/page.tsx
@@ -204,7 +204,9 @@ export default function NegotiatePage() {
             <span>•</span>
             <span>Trust Score: {provider.trustScore}/100</span>
             <span>•</span>
-            <span>Base Price: ${provider.pricePerUnit}/{provider.unit}</span>
+            <span>
+              Base Price: ${provider.pricePerUnit}/{provider.unit}
+            </span>
           </div>
         </div>
 
@@ -233,7 +235,11 @@ export default function NegotiatePage() {
                     }`}
                   >
                     <div className="text-xs text-gray-500 mb-1">
-                      {msg.type === "user" ? "You" : msg.type === "provider" ? provider.name : "System"}
+                      {msg.type === "user"
+                        ? "You"
+                        : msg.type === "provider"
+                          ? provider.name
+                          : "System"}
                     </div>
                     {msg.content}
                   </div>
@@ -303,9 +309,7 @@ export default function NegotiatePage() {
                         : "bg-red-900/30 border-red-700"
                   }`}
                 >
-                  <h3 className="font-semibold mb-2">
-                    Firewall: {firewallResult.decision}
-                  </h3>
+                  <h3 className="font-semibold mb-2">Firewall: {firewallResult.decision}</h3>
                   <p className="text-sm text-gray-300 mb-2">{firewallResult.reason}</p>
                   {firewallResult.warnings.length > 0 && (
                     <ul className="text-sm text-yellow-300 list-disc list-inside">

--- a/packages/frontend/src/app/page.tsx
+++ b/packages/frontend/src/app/page.tsx
@@ -64,7 +64,8 @@ export default function Home() {
         <section className="bg-gray-800/50 rounded-xl p-8 border border-gray-700 text-center">
           <h2 className="text-2xl font-semibold mb-4">Get Started</h2>
           <p className="text-gray-400 mb-6">
-            Learn how AI agents discover, negotiate, and pay for API services with built-in security.
+            Learn how AI agents discover, negotiate, and pay for API services with built-in
+            security.
           </p>
           <div className="flex gap-4 justify-center">
             <Link

--- a/packages/frontend/src/app/tutorial/page.tsx
+++ b/packages/frontend/src/app/tutorial/page.tsx
@@ -20,7 +20,8 @@ export default function TutorialPage() {
   const steps = [
     {
       title: "👋 はじめに",
-      description: "ZeroKey Treasuryは、AIエージェントがAPIサービスを安全に購入するためのマーケットプレイスです。",
+      description:
+        "ZeroKey Treasuryは、AIエージェントがAPIサービスを安全に購入するためのマーケットプレイスです。",
       details: `
 **主要機能:**
 - 🔍 **A2A Gateway**: AIエージェント間のサービス検索・価格交渉
@@ -195,7 +196,7 @@ CheapTranslateの特徴:
           }),
         });
         const negData = await negRes.json();
-        
+
         if (!negData.session?.id) {
           return negData;
         }
@@ -275,7 +276,9 @@ CheapTranslateの特徴:
         <div className="mb-8">
           <div className="flex justify-between text-sm text-gray-400 mb-2">
             <span>Tutorial Progress</span>
-            <span>{currentStep + 1} / {steps.length}</span>
+            <span>
+              {currentStep + 1} / {steps.length}
+            </span>
           </div>
           <div className="h-2 bg-gray-700 rounded-full">
             <div
@@ -312,12 +315,14 @@ CheapTranslateの特徴:
             )}
 
             {result && (
-              <div className={`mt-6 p-4 rounded-lg ${
-                result.success ? "bg-green-900/30 border border-green-700" : "bg-red-900/30 border border-red-700"
-              }`}>
-                <h3 className="font-semibold mb-2">
-                  {result.success ? "✅ 成功" : "❌ エラー"}
-                </h3>
+              <div
+                className={`mt-6 p-4 rounded-lg ${
+                  result.success
+                    ? "bg-green-900/30 border border-green-700"
+                    : "bg-red-900/30 border border-red-700"
+                }`}
+              >
+                <h3 className="font-semibold mb-2">{result.success ? "✅ 成功" : "❌ エラー"}</h3>
                 <pre className="text-xs overflow-x-auto">
                   {JSON.stringify(result.data || result.error, null, 2)}
                 </pre>

--- a/packages/frontend/src/lib/i18n.ts
+++ b/packages/frontend/src/lib/i18n.ts
@@ -1,0 +1,361 @@
+export type Locale = "en" | "ja";
+
+export const translations = {
+  en: {
+    // Common
+    marketplace: "Marketplace",
+    tutorial: "Tutorial",
+    dashboard: "Dashboard",
+    apiDocs: "API Docs",
+    connectWallet: "Connect Wallet",
+    next: "Next →",
+    back: "← Back",
+    search: "Search",
+    loading: "Loading...",
+    success: "Success",
+    error: "Error",
+    runApi: "🚀 Run API",
+    running: "Running...",
+
+    // Home
+    homeTitle: "Execution Governance Layer",
+    homeDescription:
+      "AI-powered execution firewall that provides safety and governance for all payments and treasury operations in a multi-chain, agent-powered world.",
+    getStarted: "Get Started",
+    startTutorial: "📖 Start Tutorial",
+    aiAnalysis: "AI Analysis",
+    aiAnalysisDesc:
+      "Semantic transaction analysis powered by LLMs to understand intent and assess risk",
+    policyEngine: "Policy Engine",
+    policyEngineDesc: "Enforce spending limits, KYC requirements, and protocol restrictions",
+    onChainGuards: "On-Chain Guards",
+    onChainGuardsDesc: "Smart contract enforcement with transparent audit trails",
+    learnHow:
+      "Learn how AI agents discover, negotiate, and pay for API services with built-in security.",
+
+    // Marketplace
+    marketplaceTitle: "📜 AI Agent API Marketplace",
+    marketplaceDesc:
+      "Discover and negotiate with AI service providers. Protected by ZeroKey Firewall.",
+    searchPlaceholder: "Search services (e.g., translation, summarization)",
+    noProviders: "No providers found",
+    trusted: "Trusted",
+    lowTrust: "Low Trust",
+    moderate: "Moderate",
+    trustScore: "Trust Score",
+    transactions: "Transactions",
+    startNegotiation: "Start Negotiation",
+    lowTrustWarning: "⚠️ Warning: Low trust score. Firewall may block transactions.",
+
+    // Tutorial
+    tutorialProgress: "Tutorial Progress",
+    step1Title: "👋 Introduction",
+    step1Desc: "ZeroKey Treasury is a marketplace for AI agents to safely purchase API services.",
+    step1Details: `
+**Key Features:**
+- 🔍 **A2A Gateway**: Service discovery and price negotiation between AI agents
+- 🛡️ **Firewall**: Risk analysis and policy checks powered by LLM
+- 💳 **x402 Payment**: API payments via USDC
+
+Click "Next" to start the tutorial!
+    `,
+    step2Title: "🔍 Step 1: Provider Discovery",
+    step2Desc: "Search for providers offering translation services.",
+    step2Details: `
+**API Request:**
+\`\`\`
+GET /api/a2a/discover?service=translation
+\`\`\`
+
+This is the first step when an enterprise AI assistant is asked to "translate this contract".
+    `,
+    step3Title: "🤝 Step 2: Start Negotiation",
+    step3Desc: "Start negotiating with a trusted provider (TranslateAI Pro).",
+    step3Details: `
+**API Request:**
+\`\`\`
+POST /api/a2a/negotiate
+{
+  "clientId": "0xYourWallet",
+  "providerId": "translate-ai-001",
+  "service": "translation",
+  "initialOffer": "0.025"
+}
+\`\`\`
+
+Offering $0.025 against the provider's asking price of $0.03.
+    `,
+    step4Title: "💬 Step 3: Price Negotiation",
+    step4Desc: "Send an offer and reach an agreement.",
+    step4Details: `
+**API Request:**
+\`\`\`
+POST /api/a2a/negotiate/{sessionId}/offer
+{
+  "amount": "0.028",
+  "type": "offer"
+}
+\`\`\`
+
+$0.028 is 90%+ of the provider price, so it should be accepted.
+    `,
+    step5Title: "🛡️ Step 4: Firewall Check",
+    step5Desc: "The Firewall analyzes the transaction risk.",
+    step5Details: `
+**API Request:**
+\`\`\`
+POST /api/firewall/check
+{
+  "sessionId": "{sessionId}"
+}
+\`\`\`
+
+Firewall checks:
+- Provider trust score
+- Transaction amount and budget
+- Anomaly patterns
+    `,
+    step6Title: "💳 Step 5: x402 Payment",
+    step6Desc: "Calling the API without payment returns a 402 error.",
+    step6Details: `
+**API Request (no payment):**
+\`\`\`
+POST /api/provider/translate
+{
+  "text": "hello",
+  "targetLanguage": "ja"
+}
+\`\`\`
+
+The 402 Payment Required response includes:
+- Required payment amount
+- USDC token address
+- Recipient address
+    `,
+    step7Title: "⚠️ Step 6: Low Trust Provider Warning",
+    step7Desc: "Choosing a suspicious provider (CheapTranslate) triggers a Firewall warning.",
+    step7Details: `
+CheapTranslate characteristics:
+- Trust Score: 15/100 (very low)
+- Price: $0.005 (1/6 of market average)
+- Transactions: only 3
+
+This is a typical fraud risk pattern.
+    `,
+    step8Title: "🎉 Complete!",
+    step8Desc: "You now understand the basic ZeroKey Treasury flow!",
+    step8Details: `
+**What you learned:**
+
+1. ✅ Provider Discovery - Find services via A2A Gateway
+2. ✅ Price Negotiation - Negotiate prices between agents
+3. ✅ Firewall Check - Risk analysis and approval/rejection
+4. ✅ x402 Payment - Pay for API usage with USDC
+5. ✅ Low Trust Warning - Block suspicious providers
+
+**Next Steps:**
+- Try the [Marketplace](/marketplace)
+- Explore the [Swagger UI](/docs)
+    `,
+    runStep2First: "Please run Step 2 first",
+
+    // Negotiation
+    negotiateWith: "Negotiate with",
+    services: "Services",
+    basePrice: "Base Price",
+    negotiationChat: "Negotiation Chat",
+    you: "You",
+    system: "System",
+    yourOffer: "Your Offer (USDC)",
+    sendOffer: "Send Offer",
+    acceptPrice: "Accept Current Price",
+    rejectExit: "Reject & Exit",
+    payUsdc: "💳 Pay",
+    connectToNegotiate: "Connect your wallet to start negotiating",
+    backToMarketplace: "← Back to Marketplace",
+  },
+  ja: {
+    // Common
+    marketplace: "マーケットプレイス",
+    tutorial: "チュートリアル",
+    dashboard: "ダッシュボード",
+    apiDocs: "API ドキュメント",
+    connectWallet: "ウォレット接続",
+    next: "次へ →",
+    back: "← 戻る",
+    search: "検索",
+    loading: "読み込み中...",
+    success: "成功",
+    error: "エラー",
+    runApi: "🚀 APIを実行",
+    running: "実行中...",
+
+    // Home
+    homeTitle: "Execution Governance Layer",
+    homeDescription:
+      "マルチチェーン・エージェント時代のすべての支払いとトレジャリー運用に安全性とガバナンスを提供するAI実行ファイアウォール。",
+    getStarted: "はじめる",
+    startTutorial: "📖 チュートリアル開始",
+    aiAnalysis: "AI分析",
+    aiAnalysisDesc: "LLMによるセマンティックなトランザクション分析で意図を理解しリスクを評価",
+    policyEngine: "ポリシーエンジン",
+    policyEngineDesc: "支出制限、KYC要件、プロトコル制限を強制",
+    onChainGuards: "オンチェーンガード",
+    onChainGuardsDesc: "透明な監査証跡を持つスマートコントラクト強制",
+    learnHow:
+      "AIエージェントがセキュリティ機能付きでAPIサービスを発見・交渉・決済する方法を学びましょう。",
+
+    // Marketplace
+    marketplaceTitle: "📜 AI Agent API マーケットプレイス",
+    marketplaceDesc: "AIサービスプロバイダを発見し交渉。ZeroKey Firewallで保護。",
+    searchPlaceholder: "サービスを検索（例：translation, summarization）",
+    noProviders: "プロバイダが見つかりません",
+    trusted: "信頼済み",
+    lowTrust: "低信頼",
+    moderate: "中程度",
+    trustScore: "信頼スコア",
+    transactions: "取引数",
+    startNegotiation: "交渉を開始",
+    lowTrustWarning:
+      "⚠️ 警告: 信頼スコアが低いです。Firewallがトランザクションをブロックする可能性があります。",
+
+    // Tutorial
+    tutorialProgress: "チュートリアル進捗",
+    step1Title: "👋 はじめに",
+    step1Desc:
+      "ZeroKey Treasuryは、AIエージェントがAPIサービスを安全に購入するためのマーケットプレイスです。",
+    step1Details: `
+**主要機能:**
+- 🔍 **A2A Gateway**: AIエージェント間のサービス検索・価格交渉
+- 🛡️ **Firewall**: LLMによるリスク分析とポリシーチェック
+- 💳 **x402 Payment**: USDCによるAPI決済
+
+「次へ」をクリックしてチュートリアルを開始しましょう！
+    `,
+    step2Title: "🔍 Step 1: プロバイダ検索",
+    step2Desc: "翻訳サービスを提供するプロバイダを検索します。",
+    step2Details: `
+**APIリクエスト:**
+\`\`\`
+GET /api/a2a/discover?service=translation
+\`\`\`
+
+これは企業AI秘書が「この契約書を翻訳して」と依頼されたときの最初のステップです。
+    `,
+    step3Title: "🤝 Step 2: 交渉開始",
+    step3Desc: "信頼できるプロバイダ(TranslateAI Pro)と交渉を開始します。",
+    step3Details: `
+**APIリクエスト:**
+\`\`\`
+POST /api/a2a/negotiate
+{
+  "clientId": "0xYourWallet",
+  "providerId": "translate-ai-001",
+  "service": "translation",
+  "initialOffer": "0.025"
+}
+\`\`\`
+
+プロバイダの希望価格$0.03に対して$0.025をオファーします。
+    `,
+    step4Title: "💬 Step 3: 価格交渉",
+    step4Desc: "オファーを送信して合意に達します。",
+    step4Details: `
+**APIリクエスト:**
+\`\`\`
+POST /api/a2a/negotiate/{sessionId}/offer
+{
+  "amount": "0.028",
+  "type": "offer"
+}
+\`\`\`
+
+$0.028はプロバイダ価格の90%以上なので、承認されるはずです。
+    `,
+    step5Title: "🛡️ Step 4: Firewallチェック",
+    step5Desc: "Firewallが取引のリスクを分析します。",
+    step5Details: `
+**APIリクエスト:**
+\`\`\`
+POST /api/firewall/check
+{
+  "sessionId": "{sessionId}"
+}
+\`\`\`
+
+Firewallは以下をチェック:
+- プロバイダの信頼スコア
+- 取引金額と予算
+- 異常パターン
+    `,
+    step6Title: "💳 Step 5: x402決済",
+    step6Desc: "決済なしでAPIを呼ぶと402エラーが返ります。",
+    step6Details: `
+**APIリクエスト (決済なし):**
+\`\`\`
+POST /api/provider/translate
+{
+  "text": "hello",
+  "targetLanguage": "ja"
+}
+\`\`\`
+
+402 Payment Requiredレスポンスには:
+- 必要な決済金額
+- USDCトークンアドレス
+- 支払い先アドレス
+    `,
+    step7Title: "⚠️ Step 6: 低信頼プロバイダの警告",
+    step7Desc: "怪しいプロバイダ(CheapTranslate)を選ぶとFirewallが警告します。",
+    step7Details: `
+CheapTranslateの特徴:
+- 信頼スコア: 15/100 (非常に低い)
+- 価格: $0.005 (市場平均の1/6)
+- 取引数: 3件のみ
+
+これは詐欺リスクの典型的なパターンです。
+    `,
+    step8Title: "🎉 完了！",
+    step8Desc: "ZeroKey Treasuryの基本フローを理解しました！",
+    step8Details: `
+**学んだこと:**
+
+1. ✅ プロバイダ検索 - A2A Gatewayでサービスを見つける
+2. ✅ 価格交渉 - エージェント間で価格を交渉
+3. ✅ Firewallチェック - リスク分析と承認/拒否
+4. ✅ x402決済 - USDCでAPI利用料を支払い
+5. ✅ 低信頼警告 - 怪しいプロバイダをブロック
+
+**次のステップ:**
+- [マーケットプレイス](/marketplace)で実際に試す
+- [Swagger UI](/docs)でAPIを探索
+    `,
+    runStep2First: "先にStep 2を実行してください",
+
+    // Negotiation
+    negotiateWith: "との交渉",
+    services: "サービス",
+    basePrice: "基本価格",
+    negotiationChat: "交渉チャット",
+    you: "あなた",
+    system: "システム",
+    yourOffer: "オファー金額 (USDC)",
+    sendOffer: "オファー送信",
+    acceptPrice: "現在の価格で承諾",
+    rejectExit: "拒否して終了",
+    payUsdc: "💳 支払う",
+    connectToNegotiate: "交渉を開始するにはウォレットを接続してください",
+    backToMarketplace: "← マーケットプレイスに戻る",
+  },
+} as const;
+
+export function getTranslation(locale: Locale) {
+  return translations[locale];
+}
+
+export function detectLocale(): Locale {
+  if (typeof window === "undefined") return "en";
+  const lang = navigator.language.toLowerCase();
+  if (lang.startsWith("ja")) return "ja";
+  return "en";
+}


### PR DESCRIPTION
Adds initial A2A/Firewall request auth spec (Ed25519 + timestamp/nonce + allowlist).\n\n- New doc: docs/a2a-firewall.md\n\nContext: spec agreed in #ZeroKey Treasury dev (A2A/Firewall).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive A2A Firewall Authentication/Authorization specification; reformatted E2E test scenarios and progress docs for improved readability.
* **New Features**
  * Introduced UI internationalization with English/Japanese translations and automatic locale detection.
* **Style / UI**
  * Small presentational markup tweaks across several pages (no behavior changes).
* **Other**
  * Response payloads now include a service label for translation/summarization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->