### PR TITLE
docs: explain A2A/Firewall on-chain vs off-chain design

### DIFF
--- a/docs/A2A_FIREWALL_DESIGN.md
+++ b/docs/A2A_FIREWALL_DESIGN.md
@@ -19,6 +19,7 @@ This doc explains the design in plain terms: what is on-chain vs off-chain, what
 ### 1.1 Off-chain (Node/TS)
 
 **Backend API (packages/backend)**
+
 - Exposes endpoints like:
   - `POST /api/a2a/negotiate`
   - `POST /api/firewall/check` (critical)
@@ -27,6 +28,7 @@ This doc explains the design in plain terms: what is on-chain vs off-chain, what
   - `packages/backend/src/middleware/a2aAuth.ts`
 
 **Clients / Agents**
+
 - UI (Next.js frontend)
 - Agent-to-agent callers
 - CLI scripts
@@ -36,6 +38,7 @@ They call the backend over HTTPS.
 ### 1.2 On-chain (Solidity)
 
 **Guard / Policy contracts**
+
 - Enforce execution constraints at the blockchain layer.
 - The chain can validate:
   - signer of a transaction (EOA / smart account)
@@ -44,6 +47,7 @@ They call the backend over HTTPS.
   - policy rules
 
 But the chain cannot:
+
 - call arbitrary HTTP endpoints
 - run heavy AI analysis
 
@@ -60,6 +64,7 @@ Even with Account Abstraction (EIP-4337), you still need off-chain services:
 - EVM does not have a standard cheap Ed25519 verify primitive.
 
 Therefore:
+
 - HTTP request signing is implemented off-chain (Node/TS).
 - On-chain uses its own signature scheme (EOA/secp256k1 or account validation).
 


### PR DESCRIPTION
Adds a plain-language design overview clarifying what belongs on-chain vs off-chain, and how the HTTP-signature based A2A/Firewall auth fits into the end-to-end flow.\n\n- New doc: docs/A2A_FIREWALL_DESIGN.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive A2A firewall design doc covering architecture, end-to-end workflow, authorization model (explicit allowlists), off-chain vs on-chain responsibilities, HTTP signing and verification practices, migration guidance, Account Abstraction considerations, and integration & payment flow recommendations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->