### PR TITLE
feat(frontend): pay confirmation modal

### DIFF
--- a/packages/frontend/src/app/negotiate/[providerId]/page.tsx
+++ b/packages/frontend/src/app/negotiate/[providerId]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from "next/navigation";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
 import { useAccount } from "wagmi";
 import Link from "next/link";
+import { PayConfirmModal } from "@/components";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
 
@@ -42,6 +43,7 @@ export default function NegotiatePage() {
   const [offerAmount, setOfferAmount] = useState("");
   const [negotiationStatus, setNegotiationStatus] = useState<string>("idle");
   const [firewallResult, setFirewallResult] = useState<FirewallResult | null>(null);
+  const [payConfirmOpen, setPayConfirmOpen] = useState(false);
   const [agreedPrice, setAgreedPrice] = useState<string | null>(null);
 
   useEffect(() => {
@@ -369,9 +371,32 @@ export default function NegotiatePage() {
                         ? "Ready to pay"
                         : "Payment is only enabled after Firewall APPROVED"
                     }
+                    onClick={() => setPayConfirmOpen(true)}
                   >
                     💳 Pay ${agreedPrice} USDC
                   </button>
+
+                  <PayConfirmModal
+                    open={payConfirmOpen}
+                    onClose={() => setPayConfirmOpen(false)}
+                    onConfirm={() => {
+                      setPayConfirmOpen(false);
+                      // TODO: wire actual payment execution
+                      addMessage("system", "Payment confirmed (demo). Next: execute payment flow.");
+                    }}
+                    confirmDisabled={firewallResult?.decision !== "APPROVED"}
+                    confirmText={`Confirm & Pay $${agreedPrice} USDC`}
+                    amountLabel={`$${agreedPrice} USDC`}
+                    recipientLabel={
+                      provider?.name ? `${provider.name} (${provider.id})` : providerId
+                    }
+                    chainLabel="Base Sepolia (demo)"
+                    firewallSummary={
+                      firewallResult
+                        ? `${firewallResult.decision}: ${firewallResult.reason}`
+                        : "Firewall result not available"
+                    }
+                  />
 
                   {firewallResult?.decision !== "APPROVED" && (
                     <div className="text-xs text-gray-400">

--- a/packages/frontend/src/components/PayConfirmModal.tsx
+++ b/packages/frontend/src/components/PayConfirmModal.tsx
@@ -1,0 +1,96 @@
+import type { ReactNode } from "react";
+
+export type PayConfirmModalProps = {
+  open: boolean;
+  title?: string;
+  amountLabel: string;
+  recipientLabel: string;
+  chainLabel: string;
+  firewallSummary: string;
+  onClose: () => void;
+  onConfirm: () => void;
+  confirmDisabled?: boolean;
+  confirmText?: string;
+  children?: ReactNode;
+};
+
+export function PayConfirmModal({
+  open,
+  title = "Confirm payment",
+  amountLabel,
+  recipientLabel,
+  chainLabel,
+  firewallSummary,
+  onClose,
+  onConfirm,
+  confirmDisabled,
+  confirmText = "Confirm & Pay",
+}: PayConfirmModalProps) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/60" onClick={onClose} aria-hidden="true" />
+
+      <div className="relative w-full max-w-lg rounded-2xl border border-gray-700 bg-gray-900 p-6 shadow-2xl">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-xl font-semibold">{title}</h2>
+            <p className="mt-1 text-sm text-gray-400">
+              Please verify the details below before proceeding.
+            </p>
+          </div>
+          <button
+            className="rounded-lg px-3 py-1 text-sm text-gray-300 hover:bg-gray-800"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="mt-5 space-y-3">
+          <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
+            <div className="text-xs uppercase tracking-wide text-gray-400">Amount</div>
+            <div className="mt-1 font-medium text-white">{amountLabel}</div>
+          </div>
+
+          <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
+            <div className="text-xs uppercase tracking-wide text-gray-400">Recipient</div>
+            <div className="mt-1 font-medium text-white break-all">{recipientLabel}</div>
+          </div>
+
+          <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
+            <div className="text-xs uppercase tracking-wide text-gray-400">Network</div>
+            <div className="mt-1 font-medium text-white">{chainLabel}</div>
+          </div>
+
+          <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
+            <div className="text-xs uppercase tracking-wide text-gray-400">Firewall summary</div>
+            <div className="mt-1 text-sm text-gray-200">{firewallSummary}</div>
+          </div>
+        </div>
+
+        <div className="mt-6 flex items-center justify-end gap-3">
+          <button
+            className="rounded-lg bg-gray-800 px-4 py-2 text-sm font-medium text-gray-200 hover:bg-gray-700"
+            onClick={onClose}
+          >
+            Cancel
+          </button>
+          <button
+            className={`rounded-lg px-4 py-2 text-sm font-semibold text-white ${
+              confirmDisabled
+                ? "bg-gray-700 cursor-not-allowed"
+                : "bg-primary-500 hover:bg-primary-600"
+            }`}
+            onClick={onConfirm}
+            disabled={confirmDisabled}
+          >
+            {confirmText}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/index.ts
+++ b/packages/frontend/src/components/index.ts
@@ -1,4 +1,5 @@
 export { TransactionAnalyzer } from "./TransactionAnalyzer";
 export { AnalysisHistory } from "./AnalysisHistory";
+export { PayConfirmModal } from "./PayConfirmModal";
 export { PolicyList } from "./PolicyList";
 export { StatsCards } from "./StatsCards";


### PR DESCRIPTION
Adds a user-facing confirmation modal before payment in negotiation flow.\n\n- Shows amount / recipient / network / firewall summary\n- Confirms before proceeding (demo confirm action for now)\n\nFiles:\n- packages/frontend/src/components/PayConfirmModal.tsx\n- packages/frontend/src/app/negotiate/[providerId]/page.tsx\n- packages/frontend/src/components/index.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a payment confirmation modal that provides a detailed confirmation step before finalizing payments. The modal displays the payment amount, recipient address, selected network/chain, and firewall approval status, allowing users to review all details before confirming the transaction.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->