### PR TITLE
docs: add 3-minute demo script

### DIFF
--- a/docs/DEMO_SCRIPT.md
+++ b/docs/DEMO_SCRIPT.md
@@ -1,0 +1,112 @@
+# Demo Script (3 minutes) — Agent buys an API with USDC (A2A + Firewall + x402)
+
+Goal: a crisp, judge-friendly demo showing **Agent Economy** with a real payment, and why ZeroKey’s control layer matters.
+
+Target URL:
+
+- `https://zerokey.exe.xyz:8000/`
+
+---
+
+## Characters
+
+- **User**: a human who delegates work
+- **Agent**: chooses a provider and pays
+- **ZeroKey Firewall**: approves/rejects and explains why
+
+---
+
+## 0:00–0:20 — Hook (what this is)
+
+Say:
+
+- “AI agents are starting to hire other agents and pay them in USDC. That’s the Agent Economy.”
+- “But if agents can pay, they can also overspend or get scammed. ZeroKey is the **execution governance layer** that sits before money leaves the wallet.”
+
+Show:
+
+- Landing page headline + the idea of ‘Execution Governance Layer’
+
+---
+
+## 0:20–1:10 — Discover & negotiate (A2A)
+
+Actions:
+
+1. Go to **Marketplace**
+2. Pick a provider (example: TranslateAI Pro)
+3. Start negotiation
+4. Send an offer / accept a price
+
+Say:
+
+- “The agent discovers providers and negotiates price — this is the A2A part.”
+
+Show:
+
+- Provider price + trust score (why an agent chooses it)
+
+---
+
+## 1:10–1:50 — Firewall decision (control layer)
+
+Actions:
+
+1. After agreement, run **Firewall check**
+2. Show the **3-state** result UI:
+   - APPROVED / WARNING / REJECTED
+   - The reason
+   - Next step guidance
+
+Say:
+
+- “This is the control layer. The Firewall explains why it’s safe or risky _before_ we pay.”
+
+If WARNING/REJECTED, say:
+
+- “Without this, an agent could blindly pay a suspicious provider.”
+
+---
+
+## 1:50–2:40 — Payment Required (x402) → USDC transfer
+
+Actions:
+
+1. Click **Pay**
+2. Show the **Confirm Payment** modal (amount/recipient/network/firewall summary)
+3. Confirm
+4. Show the **PaymentStatus** flow (processing → success)
+
+Say:
+
+- “This endpoint uses an x402-style flow: server responds Payment Required, then the agent pays in USDC, and retries/continues once verified.”
+- “We verify the USDC transfer on Base Sepolia (txHash receipt verification).”
+
+Optional proof:
+
+- Show txHash (and/or block explorer) if time
+
+---
+
+## 2:40–3:00 — Close (why it wins)
+
+Say:
+
+- “This isn’t a mock — it’s a real USDC payment flow.”
+- “ZeroKey makes Agent Economy safe: **A2A discovery + Firewall governance + USDC settlement**.”
+- “This is directly aligned with the Arc USDC treasury/agentic commerce tracks.”
+
+---
+
+## Acceptance criteria (must be true during demo)
+
+- APPROVED path can complete: Firewall → Pay confirm → processing → success
+- Payment verification uses txHash receipt checks (not just a fake ‘ok’)
+- UI clearly explains _why_ the firewall allowed/blocked
+
+---
+
+## Backup plan (if wallet/USDC not available)
+
+- Show the 402 response payload from `/api/pay/request` and explain how the wallet step works.
+- Still show Firewall decision UI and the pay confirmation UX.


### PR DESCRIPTION
Adds a judge-friendly 3-minute demo script focused on the core story: an agent buys an API using USDC via a 402 payment flow, with a pre-payment firewall decision (control layer).\n\n- docs/DEMO_SCRIPT.md\n\nAligned to Agent Economy trend + Arc USDC tracks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive demo script for the Agent Economy payment flow, including detailed walkthrough steps, UI demonstrations, acceptance criteria, and backup procedures for demo purposes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->