### PR TITLE
docs: A2A trust score model (explainable, verifiable signals)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,10 @@ ZeroKey Treasury is designed as a **global payout and treasury system** using US
 | **x402 Payment**       | HTTP 402 protocol for USDC micropayments                |
 | **On-chain Guard**     | Approval decisions recorded on blockchain               |
 | **ENS Integration**    | Decentralized identity for AI agents                    |
-| **Trust Scoring**      | Provider reputation system                              |
+| **Trust Scoring**      | Explainable trust score (payment predictability)        |
 | **Fail-safe**          | Blocks transactions when analysis fails                 |
+
+**Trust score design**: see `docs/TRUST_SCORE_MODEL.md` (verifiable signals, explainable features, not social ratings).
 
 ---
 

--- a/docs/TRUST_SCORE_MODEL.md
+++ b/docs/TRUST_SCORE_MODEL.md
@@ -1,0 +1,151 @@
+# Trust Score Model (A2A) — Definition & Design
+
+## Goal
+
+In an Agent-to-Agent (A2A) marketplace, **trust score** should answer a single question:
+
+> “If an autonomous agent pays this provider, how predictable and low-risk is the payment outcome?”
+
+This is _not_ a social rating system. The score is designed to be **explainable** and based on **verifiable facts**.
+
+---
+
+## Non-goals
+
+- Not an LLM “vibes” score.
+- Not a crowdsourced star-rating as the primary signal (easy to game).
+- Not the final approval decision.
+
+**Policy decisions** are always:
+
+- hard rules (allow/deny lists, recipient invariants, spend limits), plus
+- anomaly detection / warnings.
+
+The trust score is a **summary** used to inform WARNING vs APPROVED and to provide a compact UI signal.
+
+---
+
+## Core definition
+
+**Trust score = payment predictability score (0–100)**
+
+A provider is “trustworthy” when the _payment-related invariants_ are stable:
+
+1. **Identity & attestation**
+
+- Provider is cryptographically identifiable (A2A auth / signatures)
+- Endpoint is stable (no sudden domain changes)
+
+2. **Payment invariants** _(highest weight)_
+
+- Recipient address stability (recipient does not unexpectedly change)
+- Token + chain stability (e.g., USDC on Base Sepolia)
+- Price stability (no sudden spikes)
+
+3. **Behavioral history (local + on-chain)**
+
+- Successful purchase count
+- Failure / rejection events count
+- Time since first seen
+
+4. **Anomaly flags (negative features)**
+
+- First-seen recipient
+- Amount exceeds typical range
+- Endpoint mismatch / suspicious redirect
+
+---
+
+## Feature set (v1)
+
+The following features are **machine-verifiable** and do not require human review.
+
+### Positive features
+
+- `success_count`: number of successful verified purchases
+- `first_seen_days`: days since provider first appeared
+- `recipient_stability`: (1 - recipient_changed_count / total_purchases)
+
+### Negative features
+
+- `recipient_changed_count`: number of times payment recipient changed
+- `anomaly_amount_count`: number of times amount exceeded threshold vs historical median
+- `reject_count`: firewall rejections (or policy blocks)
+- `endpoint_changed_count`: provider endpoint changes
+
+---
+
+## Scoring method (explainable)
+
+Start with an explainable linear model (weights can be tuned later):
+
+```
+score = clamp(0, 100,
+  base
+  + w_success * log1p(success_count)
+  + w_age * log1p(first_seen_days)
+  + w_recipient_stable * recipient_stability
+  - w_recipient_change * recipient_changed_count
+  - w_reject * reject_count
+  - w_anomaly_amount * anomaly_amount_count
+  - w_endpoint_change * endpoint_changed_count
+)
+```
+
+### Why linear first?
+
+- Easy to implement
+- Easy to reason about
+- Easy to explain to judges (and to agents)
+
+Later versions can learn weights or move to probabilistic models, but **the UI must stay explainable**.
+
+---
+
+## How it is used by the Firewall
+
+**Important:** we do not “block because score is low” by itself.
+
+- **REJECT** is driven by hard rules:
+  - denylist match
+  - recipient not in provider registry / mismatch
+  - token/chain mismatch
+  - spend limit exceeded
+
+- **WARNING** is driven by:
+  - low trust score, _plus_
+  - explainable reasons (e.g., first-seen recipient, price spike)
+
+- **APPROVED** when:
+  - hard rules pass, and
+  - anomalies are absent or acceptable
+
+The output must always include **3-line reasons** (human-readable) and **next action guidance**.
+
+---
+
+## What “Trust score” means (for UI)
+
+When a user sees “Trust 78/100”, the UI should provide an explanation such as:
+
+- “12 successful purchases”
+- “Recipient address stable”
+- “No recent anomalies”
+
+And when low:
+
+- “First-time provider”
+- “Recipient has changed recently”
+- “Price spike vs history”
+
+---
+
+## Future direction: on-chain trust & invariants
+
+The long-term “native” version of this is to move key invariants and attestations to smart contracts:
+
+- Provider registry contract: maps provider identity → allowed recipient(s)
+- Signed price quotes / capability tokens
+- On-chain counters (success/fail) and slashing hooks (optional)
+
+This reduces reliance on centralized databases and makes trust signals composable for many agents.

--- a/docs/UX_EVAL_SCENARIOS.md
+++ b/docs/UX_EVAL_SCENARIOS.md
@@ -80,7 +80,7 @@ Steps:
 
 Observe:
 
-- Do you understand what “trust score” means?
+- Do you understand what “trust score” means? (It is an explainable _payment predictability_ score; see `docs/TRUST_SCORE_MODEL.md`.)
 
 Pass criteria:
 


### PR DESCRIPTION
Adds a clear, judge-facing definition of trust score for A2A agent commerce:\n\n- docs/TRUST_SCORE_MODEL.md: trust score = payment predictability (verifiable signals, explainable linear features)\n- README: clarifies trust score meaning + links to the model\n- UX_EVAL_SCENARIOS: points evaluators to the definition\n\nThis positions the project away from social ratings and toward machine-verifiable invariants + history, with a clear path to on-chain registries/attestations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined Trust Scoring description in README for greater clarity
  * Added comprehensive Trust Score Model documentation detailing scoring methodology, feature set, and firewall decision logic
  * Expanded Quick Start section with setup and startup instructions
  * Updated UX evaluation scenarios with trust score clarifications

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->