### PR TITLE
feat: recipient invariants to block recipient substitution

### DIFF
--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -18,6 +18,9 @@ const envSchema = z.object({
   A2A_KEYS_JSON: z.string().optional(),
   /** JSON array of { clientId, method, path } */
   A2A_ALLOWLIST_JSON: z.string().optional(),
+
+  /** JSON object mapping providerId -> { recipient } */
+  PROVIDER_REGISTRY_JSON: z.string().optional(),
 });
 
 const env = envSchema.parse(process.env);
@@ -30,6 +33,14 @@ function parseJson<T>(raw: string | undefined, fallback: T): T {
     return fallback;
   }
 }
+
+const DEFAULT_PROVIDER_REGISTRY: Record<string, { recipient: string }> = {
+  // Demo “verified” providers (recipient invariants)
+  "translate-ai-001": { recipient: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" },
+  "summarize-bot-001": { recipient: "0xb8c2C29ee19D8307cb7255e1Cd9CbDE883A267d5" },
+  // Demo “attack” provider: marketplace shows one recipient but registry expects another.
+  "sketchy-service-001": { recipient: "0x000000000000000000000000000000000000dEaD" },
+};
 
 export const config = {
   port: parseInt(env.PORT, 10),
@@ -49,4 +60,9 @@ export const config = {
     keys: parseJson<unknown[]>(env.A2A_KEYS_JSON, []),
     allowlist: parseJson<unknown[]>(env.A2A_ALLOWLIST_JSON, []),
   },
+
+  providerRegistry: parseJson<Record<string, { recipient: string }>>(
+    env.PROVIDER_REGISTRY_JSON,
+    DEFAULT_PROVIDER_REGISTRY
+  ),
 } as const;

--- a/packages/backend/src/routes/firewall.ts
+++ b/packages/backend/src/routes/firewall.ts
@@ -152,6 +152,13 @@ firewallRouter.post("/check", zValidator("json", checkSchema), async (c) => {
       }
     : undefined;
 
+  // If the client didn't specify an onchain destination, assume the provider's recipient.
+  if (!input.to && providerRow?.walletAddress) {
+    tx.to = providerRow.walletAddress;
+  }
+
+  const expectedRecipient = providerId ? config.providerRegistry[providerId]?.recipient : undefined;
+
   const providerForFirewall = providerRow
     ? {
         id: providerRow.id,
@@ -159,6 +166,8 @@ firewallRouter.post("/check", zValidator("json", checkSchema), async (c) => {
         trustScore: providerRow.trustScore,
         priceWei: providerRow.pricePerUnit,
         service: providerRow.services?.[0] ?? undefined,
+        expectedRecipient,
+        recipient: providerRow.walletAddress ?? undefined,
       }
     : undefined;
 


### PR DESCRIPTION
Implements the core demo rejection: block payment recipient substitution before money moves.\n\n- Adds provider registry (config.providerRegistry; env override via PROVIDER_REGISTRY_JSON)\n- Firewall: if provider recipient != registry recipient => REJECTED with explainable reasons\n- Firewall: if provider has recipient but is not in registry => WARNING (unverified recipient)\n- Firewall check now auto-sets tx.to to provider wallet when the client omits it\n- Pay 402 request/submit now resolve the payment recipient from the provider listing (wallet_address)\n\nThis enables a reliable demo scenario: choose a provider whose marketplace recipient mismatches the registry and show REJECTED with clear rationale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable provider registry enabling dynamic mapping of provider IDs to payment recipients via environment configuration.
  * Implemented enhanced recipient verification in firewall checks to detect and prevent potential fraud and recipient substitution attacks.

* **Bug Fixes**
  * Improved payment routing with fallback recipient handling for cases where provider configurations are incomplete.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->