### PR TITLE
test: cover recipient mismatch rejection + blocked audit events

### DIFF
--- a/packages/backend/src/routes/firewallEvents.test.ts
+++ b/packages/backend/src/routes/firewallEvents.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import app from "../index.js";
+import { db, schema } from "../db/index.js";
+
+describe("/api/firewall/events", () => {
+  it("lists blocked-before-payment events", async () => {
+    const id = `evt-${Date.now()}`;
+
+    await db.insert(schema.firewallEvents).values({
+      id,
+      providerId: "sketchy-service-001",
+      providerName: "CheapTranslate",
+      decision: "REJECTED",
+      reason: "Recipient mismatch",
+      attemptedRecipient: "0x0000000000000000000000000000000000000001",
+      amountUsdc: "0.005",
+      createdAt: new Date().toISOString(),
+    });
+
+    const res = await app.request(new Request("http://example.com/api/firewall/events"));
+    expect(res.status).toBe(200);
+
+    const json = (await res.json()) as any;
+    expect(json.success).toBe(true);
+    expect(Array.isArray(json.events)).toBe(true);
+
+    const found = json.events.find((e: any) => e.id === id);
+    expect(found).toBeTruthy();
+    expect(found.decision).toBe("REJECTED");
+  });
+});

--- a/packages/backend/src/services/firewall.recipientInvariant.test.ts
+++ b/packages/backend/src/services/firewall.recipientInvariant.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { checkFirewall } from "../services/firewall.js";
+
+describe("Firewall recipient invariants", () => {
+  it("rejects when provider recipient mismatches verified registry recipient", async () => {
+    const res = await checkFirewall({
+      tx: {
+        chainId: 84532,
+        from: "0x0000000000000000000000000000000000000001",
+        to: "0x0000000000000000000000000000000000000002",
+        value: "1000000", // 1 USDC (base units)
+      },
+      provider: {
+        id: "sketchy-service-001",
+        name: "CheapTranslate",
+        trustScore: 50,
+        expectedRecipient: "0x000000000000000000000000000000000000dEaD",
+        recipient: "0x0000000000000000000000000000000000000001",
+      },
+    });
+
+    expect(res.decision).toBe("REJECTED");
+    expect(res.reasons.join("\n")).toMatch(/Recipient mismatch/i);
+    expect(res.reasons.join("\n")).toMatch(/fraud risk/i);
+  });
+});


### PR DESCRIPTION
Adds two high-signal tests to lock demo behavior:\n\n- Unit: firewall recipient invariants reject on mismatch (REJECTED + reasons)\n- Route: /api/firewall/events returns blocked-before-payment audit events\n\nThese tests protect the core demo highlight (BLOCKED + money never moved).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for firewall events API endpoint to validate successful response handling and event retrieval.
  * Added test coverage for recipient validation logic in firewall processes to ensure fraud risk detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->