### PR TITLE
feat: ERC-8004 identity registry viewer (read-only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,7 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
 .DS_Store
+
+# Foundry
+packages/contracts/broadcast/
+packages/contracts/cache/

--- a/packages/frontend/src/app/negotiate/[providerId]/page.tsx
+++ b/packages/frontend/src/app/negotiate/[providerId]/page.tsx
@@ -6,7 +6,12 @@ import { ConnectButton } from "@rainbow-me/rainbowkit";
 import { useAccount, usePublicClient, useWalletClient } from "wagmi";
 import Link from "next/link";
 import { erc20Abi, parseUnits } from "viem";
-import { PayConfirmModal, PaymentStatusModal, DemoBalanceGuard } from "@/components";
+import {
+  PayConfirmModal,
+  PaymentStatusModal,
+  DemoBalanceGuard,
+  Erc8004IdentityCard,
+} from "@/components";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
 
@@ -17,6 +22,8 @@ interface Provider {
   pricePerUnit: string;
   unit: string;
   trustScore: number;
+  walletAddress?: string;
+  ensName?: string;
 }
 
 interface NegotiationMessage {
@@ -262,6 +269,9 @@ export default function NegotiatePage() {
             <div className="space-y-4">
               {/* Demo rail UI (judges should never wonder "where are we?") */}
               <DemoBalanceGuard />
+
+              {/* ERC-8004 (read-only) identity signals */}
+              <Erc8004IdentityCard agentAddress={provider.walletAddress} />
 
               <div className="rounded-xl border border-white/10 bg-white/5 p-4">
                 <div className="text-xs uppercase tracking-widest text-gray-400">Demo Flow</div>

--- a/packages/frontend/src/components/Erc8004IdentityCard.tsx
+++ b/packages/frontend/src/components/Erc8004IdentityCard.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useMemo } from "react";
+import { getAddress, isAddress, type Address } from "viem";
+import { useReadContract } from "wagmi";
+
+const BASE_SEPOLIA_CHAIN_ID = 84532;
+
+// ERC-8004 Identity Registry (verified on Base Sepolia)
+// https://sepolia.basescan.org/address/0x4102F9b209796b53a18B063A438D05C7C9Af31A2
+const ERC8004_IDENTITY_REGISTRY = "0x4102F9b209796b53a18B063A438D05C7C9Af31A2" as const;
+
+const erc8004IdentityAbi = [
+  {
+    type: "function",
+    name: "isRegistered",
+    stateMutability: "view",
+    inputs: [{ name: "_address", type: "address" }],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "getTokenId",
+    stateMutability: "view",
+    inputs: [{ name: "_address", type: "address" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "getAgentProfile",
+    stateMutability: "view",
+    inputs: [{ name: "_tokenId", type: "uint256" }],
+    outputs: [
+      { name: "name", type: "string" },
+      { name: "endpoint", type: "string" },
+      { name: "capabilitiesHash", type: "bytes32" },
+      { name: "registeredAt", type: "uint256" },
+      { name: "isActive", type: "bool" },
+      { name: "metadata", type: "string" },
+    ],
+  },
+] as const;
+
+function shorten(s: string, left = 10, right = 8) {
+  if (s.length <= left + right + 3) return s;
+  return `${s.slice(0, left)}…${s.slice(-right)}`;
+}
+
+export function Erc8004IdentityCard({ agentAddress }: { agentAddress?: string | null }) {
+  const addr = useMemo(() => {
+    if (!agentAddress) return null;
+    if (!isAddress(agentAddress)) return null;
+    return getAddress(agentAddress) as Address;
+  }, [agentAddress]);
+
+  const reg = useReadContract({
+    address: ERC8004_IDENTITY_REGISTRY,
+    abi: erc8004IdentityAbi,
+    functionName: "isRegistered",
+    args: addr ? [addr] : undefined,
+    chainId: BASE_SEPOLIA_CHAIN_ID,
+    query: { enabled: !!addr },
+  });
+
+  const tokenId = useReadContract({
+    address: ERC8004_IDENTITY_REGISTRY,
+    abi: erc8004IdentityAbi,
+    functionName: "getTokenId",
+    args: addr ? [addr] : undefined,
+    chainId: BASE_SEPOLIA_CHAIN_ID,
+    query: { enabled: !!addr },
+  });
+
+  const profile = useReadContract({
+    address: ERC8004_IDENTITY_REGISTRY,
+    abi: erc8004IdentityAbi,
+    functionName: "getAgentProfile",
+    // Only call when tokenId is non-zero
+    args: typeof tokenId.data === "bigint" && tokenId.data > 0n ? [tokenId.data] : undefined,
+    chainId: BASE_SEPOLIA_CHAIN_ID,
+    query: { enabled: typeof tokenId.data === "bigint" && tokenId.data > 0n },
+  });
+
+  const basescanUrl = `https://sepolia.basescan.org/address/${ERC8004_IDENTITY_REGISTRY}`;
+
+  return (
+    <div className="rounded-xl border border-white/10 bg-white/5 p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-xs uppercase tracking-widest text-gray-400">ERC-8004</div>
+          <div className="mt-1 text-sm text-gray-200">Onchain Identity Registry (read-only)</div>
+        </div>
+        <a
+          href={basescanUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="text-xs text-cyan-300 hover:text-cyan-200"
+        >
+          BaseScan ↗
+        </a>
+      </div>
+
+      {!addr ? (
+        <div className="mt-3 text-xs text-gray-400">
+          Provider wallet address missing or invalid.
+        </div>
+      ) : reg.isLoading || tokenId.isLoading ? (
+        <div className="mt-3 text-xs text-gray-400">Loading ERC-8004 identity…</div>
+      ) : reg.isError || tokenId.isError ? (
+        <div className="mt-3 text-xs text-red-200">Failed to read ERC-8004 registry.</div>
+      ) : reg.data === false || tokenId.data === 0n ? (
+        <div className="mt-3 text-xs text-gray-300">Not registered in the Identity Registry.</div>
+      ) : (
+        <div className="mt-3 space-y-2">
+          <div className="flex justify-between text-xs">
+            <span className="text-gray-400">Token ID</span>
+            <span className="text-gray-200">{tokenId.data?.toString()}</span>
+          </div>
+
+          {profile.isLoading ? (
+            <div className="text-xs text-gray-400">Loading profile…</div>
+          ) : profile.isError || !profile.data ? (
+            <div className="text-xs text-red-200">Failed to load profile.</div>
+          ) : (
+            <>
+              <div className="flex justify-between text-xs gap-3">
+                <span className="text-gray-400">Name</span>
+                <span className="text-gray-200 text-right">{profile.data[0]}</span>
+              </div>
+              <div className="flex justify-between text-xs gap-3">
+                <span className="text-gray-400">Endpoint</span>
+                <span className="text-gray-200 text-right" title={profile.data[1]}>
+                  {shorten(profile.data[1] || "")}
+                </span>
+              </div>
+              <div className="flex justify-between text-xs gap-3">
+                <span className="text-gray-400">Active</span>
+                <span className="text-gray-200">{profile.data[4] ? "Yes" : "No"}</span>
+              </div>
+            </>
+          )}
+
+          <div className="text-[11px] text-gray-400 pt-1 border-t border-white/10">
+            Shows ERC-8004 identity signals on Base Sepolia. (We use this as a trust signal source;
+            payments are still governed by ZeroKey policy.)
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/index.ts
+++ b/packages/frontend/src/components/index.ts
@@ -5,6 +5,7 @@ export { PaymentStatusModal } from "./PaymentStatusModal";
 export { PurchaseLogCard } from "./PurchaseLogCard";
 export { BlockedAuditLogCard } from "./BlockedAuditLogCard";
 export { DemoBalanceGuard } from "./DemoBalanceGuard";
+export { Erc8004IdentityCard } from "./Erc8004IdentityCard";
 export { PolicyList } from "./PolicyList";
 export { StatsCards } from "./StatsCards";
 export { EnsProfileCard, EnsName } from "./EnsProfile";


### PR DESCRIPTION
Adds a minimal, demo-safe ERC-8004 integration by reading the verified Identity Registry on Base Sepolia and showing the provider's onchain identity signals (tokenId, name, endpoint, active).\n\n- New component: Erc8004IdentityCard (read-only)\n- Placed on Negotiate side-rail under the demo readiness card\n- Uses Base Sepolia Identity Registry: 0x4102F9b209796b53a18B063A438D05C7C9Af31A2 (BaseScan verified)\n- Also ignores Foundry broadcast/cache artifacts in .gitignore\n\nNote: this is intentionally NOT claiming full ERC-8004 compliance; it is a trust-signal viewer we can demo reliably.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ERC-8004 identity card display on provider negotiation page showing registration status, token ID, and profile information with network verification links.

* **Chores**
  * Updated build artifact ignore patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->