### PR TITLE
docs: add optional ERC-8004 identity check to demo checklist

### DIFF
--- a/docs/DEMO_CHECKLIST.md
+++ b/docs/DEMO_CHECKLIST.md
@@ -20,6 +20,7 @@ Optional sanity checks:
 
 - [ ] Dashboard loads (Stats + Purchase Log + Blocked Audit Log render)
 - [ ] Purchase Log shows existing entries (or “No purchases yet”)
+- [ ] (Optional) ERC-8004 Identity viewer shows onchain identity signals for a provider (Base Sepolia)
 
 ---
 


### PR DESCRIPTION
Adds one optional sanity check to DEMO_CHECKLIST.md for the ERC-8004 Identity viewer (Base Sepolia).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added optional checklist item enabling verification that the ERC-8004 Identity viewer displays onchain identity signals for providers on the Base Sepolia testnet network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->