### PR TITLE
docs: refresh README/demo script/sponsor map

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,14 @@
 
 AI agents are overconfident interns. **ZeroKey is the CFO standing between your agent and your wallet.**
 
-ZeroKey Treasury is an **execution firewall** for agent-to-agent commerce: agents discover providers, negotiate, run a policy check (recipient invariants, spend limits, anomaly checks), then pay in USDC using an HTTP 402 flow. All outcomes are auditable: we persist txHash for successful settlement, and we log blocked events as “money never moved”.
+ZeroKey Treasury is an **execution firewall** for agent-to-agent commerce: agents discover providers, negotiate, run a policy check (recipient invariants, spend limits, anomaly checks), then pay in USDC using an HTTP 402 flow.
+
+All outcomes are auditable:
+
+- **APPROVED** → we verify the USDC transfer by on-chain receipt (txHash) and persist a Purchase Log
+- **REJECTED** → we write a Blocked Audit Log event (“money never moved”)
+
+Bonus (read-only): we also show **ERC-8004 Identity Registry** signals on Base Sepolia as an on-chain trust signal source (not claiming full compliance).
 
 ## 🎬 Demo
 

--- a/docs/DEMO_SCRIPT.md
+++ b/docs/DEMO_SCRIPT.md
@@ -34,9 +34,9 @@ Show:
 Actions:
 
 1. Go to **Marketplace**
-2. Pick a provider (example: TranslateAI Pro)
+2. Pick **ImagePack** (success flow)
 3. Start negotiation
-4. Send an offer / accept a price
+4. Accept price
 
 Say:
 
@@ -44,7 +44,8 @@ Say:
 
 Show:
 
-- Provider price + trust score (why an agent chooses it)
+- Provider price + trust score
+- (Optional) **ERC-8004 Identity** viewer: on-chain identity + endpoint (read-only)
 
 ---
 
@@ -53,18 +54,17 @@ Show:
 Actions:
 
 1. After agreement, run **Firewall check**
-2. Show the **3-state** result UI:
-   - APPROVED / WARNING / REJECTED
-   - The reason
-   - Next step guidance
+2. Show the decision (APPROVED / REJECTED) and the reason
 
 Say:
 
-- “This is the control layer. The Firewall explains why it’s safe or risky _before_ we pay.”
+- “The Firewall explains why it’s safe or risky _before_ we pay.”
 
-If WARNING/REJECTED, say:
+Note:
 
-- “Without this, an agent could blindly pay a suspicious provider.”
+- For the full narrative, we run **Success → Blocked → Success**.
+  - Success: ImagePack (APPROVED)
+  - Blocked: CheapTranslate (REJECTED, money never moved)
 
 ---
 
@@ -76,15 +76,16 @@ Actions:
 2. Show the **Confirm Payment** modal (amount/recipient/network/firewall summary)
 3. Confirm
 4. Show the **PaymentStatus** flow (processing → success)
+5. Click the txHash / open BaseScan
 
 Say:
 
-- “This endpoint uses an x402-style flow: server responds Payment Required, then the agent pays in USDC, and retries/continues once verified.”
-- “We verify the USDC transfer on Base Sepolia (txHash receipt verification).”
+- “This endpoint uses an x402-style flow: server responds Payment Required, then the agent pays in USDC.”
+- “The backend verifies the USDC transfer by **waiting for the on-chain receipt** and decoding the Transfer event.”
 
-Optional proof:
+Proof (important):
 
-- Show txHash (and/or block explorer) if time
+- Show the **txHash** and open it on BaseScan Sepolia.
 
 ---
 
@@ -108,5 +109,17 @@ Say:
 
 ## Backup plan (if wallet/USDC not available)
 
+- Run the **Blocked** flow (CheapTranslate) and emphasize:
+  - “Money never moved” (audit log proof)
 - Show the 402 response payload from `/api/pay/request` and explain how the wallet step works.
-- Still show Firewall decision UI and the pay confirmation UX.
+
+## Dev-only reliability check (optional)
+
+If you need a quick sanity check before a demo:
+
+```bash
+pnpm dev:backend
+pnpm --filter backend exec tsx ../../scripts/smoke-demo.ts
+```
+
+This prints a fresh BaseScan txHash you can keep as backup proof.

--- a/docs/SPONSOR_TECH_MAP.md
+++ b/docs/SPONSOR_TECH_MAP.md
@@ -51,6 +51,22 @@ This document lists **exact code locations (file + line ranges)** for sponsor / 
 
 ---
 
+## ERC-8004 (Trustless Agents) — on-chain identity signals (read-only)
+
+> We do **not** claim full ERC-8004 compliance in this project.
+> We integrate the ERC-8004 **Identity Registry as a read-only trust signal source**.
+
+- `packages/frontend/src/components/Erc8004IdentityCard.tsx`
+  - Reads Identity Registry on Base Sepolia:
+    - registry: `0x4102F9b209796b53a18B063A438D05C7C9Af31A2`
+    - chainId: `84532`
+  - Displays: registered?, tokenId, (name/endpoint/active)
+
+- `packages/frontend/src/app/negotiate/[providerId]/page.tsx`
+  - Renders the ERC-8004 Identity viewer in the demo side-rail
+
+---
+
 ## Notes
 
 - This project uses **real on-chain settlement on Base Sepolia** (not a mock): we verify tx receipts and persist txHash in logs.


### PR DESCRIPTION
Updates docs to match the current, working demo:\n\n- README: clarifies APPROVED vs REJECTED audit outcomes, mentions ERC-8004 Identity viewer (read-only)\n- DEMO_SCRIPT: updated to the Success→Blocked→Success run and explicitly calls out txHash/BaseScan proof + smoke-demo script\n- SPONSOR_TECH_MAP: adds ERC-8004 (Identity Registry) read-only integration locations\n\nNo behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded audit outcomes documentation with detailed APPROVED/REJECTED path descriptions including on-chain receipt verification
  * Enhanced demo script with updated provider examples, refined Firewall decision flow, and on-chain verification instructions
  * Added documentation for ERC-8004 on-chain identity signals feature

<!-- end of auto-generated comment: release notes by coderabbit.ai -->