### PR TITLE
fix: use relative API URLs for external access

### DIFF
--- a/packages/frontend/src/app/marketplace/page.tsx
+++ b/packages/frontend/src/app/marketplace/page.tsx
@@ -16,7 +16,7 @@ interface Provider {
   walletAddress?: string;
 }
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
 
 export default function MarketplacePage() {
   const [providers, setProviders] = useState<Provider[]>([]);

--- a/packages/frontend/src/app/negotiate/[providerId]/page.tsx
+++ b/packages/frontend/src/app/negotiate/[providerId]/page.tsx
@@ -13,7 +13,7 @@ import {
   Erc8004IdentityCard,
 } from "@/components";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
 
 interface Provider {
   id: string;

--- a/packages/frontend/src/app/tutorial/page.tsx
+++ b/packages/frontend/src/app/tutorial/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
 
 interface StepResult {
   success: boolean;

--- a/packages/frontend/src/components/BlockedAuditLogCard.tsx
+++ b/packages/frontend/src/components/BlockedAuditLogCard.tsx
@@ -13,7 +13,7 @@ type FirewallEvent = {
   createdAt: string;
 };
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
 
 function providerLabel(e: FirewallEvent) {
   if (e.providerName && e.providerId && e.providerName !== e.providerId) {

--- a/packages/frontend/src/components/PurchaseLogCard.tsx
+++ b/packages/frontend/src/components/PurchaseLogCard.tsx
@@ -17,7 +17,7 @@ type Purchase = {
   createdAt: string;
 };
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
 
 function shortHash(h: string) {
   if (!h || h.length < 10) return h;

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -2,7 +2,7 @@
  * ZeroKey Backend API Client
  */
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "";
 
 /**
  * Transaction input for analysis


### PR DESCRIPTION
All API calls now use relative paths instead of hardcoded localhost:3001.

Works through the Next.js reverse proxy on exe.xyz.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API endpoint configuration across frontend components and pages to use relative paths instead of hardcoded localhost URLs, ensuring API requests resolve against the current application origin when environment variables are not explicitly set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->