### PR TITLE
fix: use empty API_URL for production (Next.js rewrites)

### DIFF
--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -2,4 +2,6 @@
 # Copy to .env.local and fill in values
 
 NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=
-NEXT_PUBLIC_API_URL=http://localhost:3001
+# Leave empty to use Next.js rewrites (recommended for production)
+# Set to http://localhost:3001 only for local development without Next.js
+NEXT_PUBLIC_API_URL=


### PR DESCRIPTION
## Summary
- Changed default `NEXT_PUBLIC_API_URL` to empty string in `.env.example`
- This allows Next.js rewrites to proxy API calls properly

## Problem
When accessing from external URLs (e.g., `https://zerokey.exe.xyz:8000/`), the frontend was trying to call `http://localhost:3001` which doesn't work from the browser.

## Solution
Use empty `NEXT_PUBLIC_API_URL` so that API calls go to relative paths (`/api/...`), which Next.js rewrites to the backend.

## Testing
- Verified on https://zerokey.exe.xyz:8000/
- Dashboard, Marketplace, and all API calls work correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated environment configuration guidance to clarify API endpoint setup for production and local development scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->