### PR TITLE
fix: demo trust scores, wallet addresses, and proxy rewrites

### DIFF
--- a/packages/backend/src/db/index.ts
+++ b/packages/backend/src/db/index.ts
@@ -370,12 +370,12 @@ export function initializeDatabase(): void {
     );
   }
 
-  // Ensure existing providers get wallet/ENS metadata.
+  // Ensure existing providers have correct wallet/ENS metadata.
   const update = sqlite.prepare(`
-      UPDATE providers SET wallet_address = ?, ens_name = ? WHERE id = ? AND wallet_address IS NULL
+      UPDATE providers SET wallet_address = ?, ens_name = ?, trust_score = ? WHERE id = ?
     `);
   for (const provider of DEMO_PROVIDERS) {
-    update.run(provider.wallet_address, provider.ens_name, provider.id);
+    update.run(provider.wallet_address, provider.ens_name, provider.trust_score, provider.id);
   }
 }
 

--- a/packages/backend/src/routes/a2a.ts
+++ b/packages/backend/src/routes/a2a.ts
@@ -54,8 +54,8 @@ app.get("/discover", zValidator("query", discoverQuerySchema), async (c) => {
         }
         return {
           ...p,
-          // Use on-chain score if available, otherwise fall back to DB value
-          calculatedTrustScore: trustResult?.score ?? p.trustScore,
+          // Use the higher of on-chain score and DB seeded value
+          calculatedTrustScore: Math.max(trustResult?.score ?? 0, p.trustScore),
           trustBreakdown: trustResult?.breakdown ?? null,
         };
       })

--- a/packages/frontend/next.config.ts
+++ b/packages/frontend/next.config.ts
@@ -12,6 +12,18 @@ const nextConfig: NextConfig = {
   async rewrites() {
     return [
       {
+        source: "/health",
+        destination: "http://localhost:3001/health",
+      },
+      {
+        source: "/docs",
+        destination: "http://localhost:3001/docs",
+      },
+      {
+        source: "/docs/:path*",
+        destination: "http://localhost:3001/docs/:path*",
+      },
+      {
         source: "/api/openapi",
         destination: "http://localhost:3001/docs/openapi.json",
       },

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -130,7 +130,10 @@ async function fetchApi<T>(endpoint: string, options?: globalThis.RequestInit): 
 
   if (!response.ok) {
     const error = await response.json().catch(() => ({ message: "Unknown error" }));
-    const errorMessage = error.message || (typeof error.error === 'string' ? error.error : JSON.stringify(error.error)) || "Request failed";
+    const errorMessage =
+      error.message ||
+      (typeof error.error === "string" ? error.error : JSON.stringify(error.error)) ||
+      "Request failed";
     throw new ApiError(response.status, errorMessage);
   }
 


### PR DESCRIPTION
## Summary
- **Trust scores showing 0 in marketplace**: `??` operator in discover endpoint treated `0` as non-nullish, preventing fallback to DB seeded values. Changed to `Math.max(onChain, db)` so the higher score is always used.
- **Stale wallet addresses (vitalik's address)**: DB migration had `WHERE wallet_address IS NULL` guard, so existing records with old addresses were never updated. Removed the guard to always sync seed data.
- **`/health` and `/docs` not reachable on exe.dev**: Only port 8000 is exposed (no nginx), so added Next.js rewrites for these backend endpoints.

## Test plan
- [x] Trust scores: ImagePack=92, TranslateAI Pro=85, CheapTranslate=15
- [x] Firewall: ImagePack APPROVED, CheapTranslate REJECTED
- [x] x402 pay/request returns correct provider wallet `0xae0D...`
- [x] `/health` returns 200 via Next.js rewrite
- [x] All frontend pages render (marketplace, dashboard, setup)
- [x] Gateway endpoints return real Circle API data
- [x] Backend and frontend build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Trust score used during provider discovery now takes the higher of on-chain and stored values for more reliable results.

* **Improvements**
  * Provider metadata synchronization now reliably refreshes stored trust scores and provider identifiers.

* **New Features**
  * Added routing to expose health check and documentation endpoints through the frontend.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->