### PR TITLE
feat: make guard-demo (wallet-enforced recipient invariant)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install build test lint format typecheck dev backend frontend demo demo-local demo-hosted agent-demo agent-demo-blocked
+.PHONY: help install build test lint format typecheck dev backend frontend demo demo-local demo-hosted agent-demo agent-demo-blocked guard-demo
 
 # Load .env if exists
 ifneq (,$(wildcard .env))
@@ -112,6 +112,24 @@ agent-demo:
 
 agent-demo-blocked:
 	cd packages/backend && pnpm tsx ../../scripts/agent-demo-blocked.ts
+
+# Wallet-enforced guard demo (deploy Safe guard contract)
+# Requires Foundry installed.
+# Env (examples):
+#   PRIVATE_KEY=<uint> USDC_ADDRESS=0x... EXPECTED_RECIPIENT=0x... SAFE_ADDRESS=0xYourSafe
+#
+# Deploys: packages/contracts/script/DeployRecipientInvariantGuard.s.sol
+
+guard-demo:
+	@echo "Deploying RecipientInvariantGuard (Safe Guard)..."
+	@echo "Required env: PRIVATE_KEY (uint), USDC_ADDRESS, EXPECTED_RECIPIENT"
+	@echo "Optional env: SAFE_ADDRESS (defaults to 0x0 = any Safe)"
+	cd packages/contracts && forge script script/DeployRecipientInvariantGuard.s.sol:DeployRecipientInvariantGuardScript \
+		--rpc-url $${RPC_URL:-$${BASE_SEPOLIA_RPC_URL:-https://sepolia.base.org}} \
+		--broadcast \
+		--legacy
+	@echo "\nNext (Safe UI): set Guard to the deployed address, then try USDC transfer to wrong recipient (revert) and to EXPECTED_RECIPIENT (success)."
+	@echo "See docs/GUARD_DEMO.md"
 
 export_pdf:        # Export pitch deck to PDF using Marp
 	npx marp pitch_deck.md --pdf --allow-local-files --html

--- a/docs/GUARD_DEMO.md
+++ b/docs/GUARD_DEMO.md
@@ -1,0 +1,54 @@
+# Wallet-Enforced Guard Demo (60 seconds)
+
+Goal: prove **agents don't choose security** — the **wallet enforces** the recipient.
+
+## What this demo shows
+
+- An agent (or attacker) tries to send **USDC** to the wrong recipient.
+- The Safe transaction **reverts on-chain** with `RecipientMismatch(expected, got)`.
+- Sending to the correct recipient succeeds and produces a **txHash**.
+
+## One-line script (for subtitles)
+
+> Agents don't choose security. The wallet enforces the recipient.
+
+## Prereqs
+
+- Base Sepolia Safe (or any Safe on a supported chain)
+- Base Sepolia USDC token address (demo): `0x036CbD53842c5426634e7929541eC2318f3dCF7e`
+- A funded deployer EOA (gas)
+
+## Run (deploy guard)
+
+Create `.env` at repo root (or export env vars):
+
+```bash
+# Foundry deploy key (as uint) - do NOT commit
+PRIVATE_KEY=...
+
+# Base Sepolia USDC
+USDC_ADDRESS=0x036CbD53842c5426634e7929541eC2318f3dCF7e
+
+# optional: restrict guard to a single Safe
+SAFE_ADDRESS=0xYourSafe
+
+# the only allowed recipient for USDC transfers
+EXPECTED_RECIPIENT=0xExpected
+```
+
+Deploy:
+
+```bash
+make guard-demo
+```
+
+## Manual steps (Safe UI)
+
+1) In Safe UI, set Guard = deployed `RecipientInvariantGuard` address.
+2) Try USDC transfer **to a wrong address** → should revert.
+3) Try USDC transfer **to EXPECTED_RECIPIENT** → should succeed and show txHash.
+
+## What to capture on video
+
+- Revert on the wrong-recipient tx (show the revert reason)
+- Success txHash on the correct-recipient tx

--- a/docs/GUARD_DEMO.md
+++ b/docs/GUARD_DEMO.md
@@ -44,9 +44,9 @@ make guard-demo
 
 ## Manual steps (Safe UI)
 
-1) In Safe UI, set Guard = deployed `RecipientInvariantGuard` address.
-2) Try USDC transfer **to a wrong address** → should revert.
-3) Try USDC transfer **to EXPECTED_RECIPIENT** → should succeed and show txHash.
+1. In Safe UI, set Guard = deployed `RecipientInvariantGuard` address.
+2. Try USDC transfer **to a wrong address** → should revert.
+3. Try USDC transfer **to EXPECTED_RECIPIENT** → should succeed and show txHash.
 
 ## What to capture on video
 

--- a/packages/contracts/script/DeployRecipientInvariantGuard.s.sol
+++ b/packages/contracts/script/DeployRecipientInvariantGuard.s.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Script, console2} from "forge-std/Script.sol";
+import {RecipientInvariantGuard} from "../src/RecipientInvariantGuard.sol";
+
+/**
+ * DeployRecipientInvariantGuard
+ *
+ * Env:
+ * - PRIVATE_KEY (uint)
+ * - USDC_ADDRESS (address)
+ * - SAFE_ADDRESS (address) (optional, 0x0 to disable)
+ * - EXPECTED_RECIPIENT (address)
+ */
+contract DeployRecipientInvariantGuardScript is Script {
+    function run() public {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address usdc = vm.envAddress("USDC_ADDRESS");
+        address safe = vm.envOr("SAFE_ADDRESS", address(0));
+        address expected = vm.envAddress("EXPECTED_RECIPIENT");
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        RecipientInvariantGuard guard = new RecipientInvariantGuard(usdc, safe, expected);
+
+        console2.log("RecipientInvariantGuard deployed at:", address(guard));
+        console2.log("USDC:", usdc);
+        console2.log("SAFE:", safe);
+        console2.log("EXPECTED_RECIPIENT:", expected);
+
+        vm.stopBroadcast();
+    }
+}

--- a/packages/contracts/src/RecipientInvariantGuard.sol
+++ b/packages/contracts/src/RecipientInvariantGuard.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Enum} from "safe-smart-account/contracts/interfaces/Enum.sol";
+import {BaseTransactionGuard} from "safe-smart-account/contracts/base/GuardManager.sol";
+
+/**
+ * @title RecipientInvariantGuard
+ * @notice Minimal Safe Guard for the demo: enforce that USDC transfers can only go to an expected recipient.
+ *
+ * This is the wallet-enforced proof that "agents don't choose security".
+ * If an agent (or attacker) tries to transfer USDC to a different recipient, the Safe tx reverts.
+ */
+contract RecipientInvariantGuard is BaseTransactionGuard {
+    address public owner;
+
+    /// @notice Token contract (USDC) to guard.
+    address public immutable usdc;
+
+    /// @notice Expected recipient for USDC transfers.
+    address public expectedRecipient;
+
+    /// @notice The Safe this guard is intended for (optional safety).
+    address public safe;
+
+    // ERC20 transfer selector: transfer(address,uint256)
+    bytes4 internal constant TRANSFER_SELECTOR = 0xa9059cbb;
+
+    event Configured(address indexed safe, address indexed usdc, address indexed expectedRecipient);
+    event ExpectedRecipientUpdated(address indexed oldRecipient, address indexed newRecipient);
+
+    error NotOwner();
+    error NotSafe();
+    error RecipientMismatch(address expected, address got);
+
+    modifier onlyOwner() {
+        if (msg.sender != owner) revert NotOwner();
+        _;
+    }
+
+    constructor(address _usdc, address _safe, address _expectedRecipient) {
+        owner = msg.sender;
+        usdc = _usdc;
+        safe = _safe;
+        expectedRecipient = _expectedRecipient;
+        emit Configured(_safe, _usdc, _expectedRecipient);
+    }
+
+    function setExpectedRecipient(address newRecipient) external onlyOwner {
+        address old = expectedRecipient;
+        expectedRecipient = newRecipient;
+        emit ExpectedRecipientUpdated(old, newRecipient);
+    }
+
+    function setSafe(address newSafe) external onlyOwner {
+        safe = newSafe;
+    }
+
+    /**
+     * @dev Called by Safe before executing a tx.
+     * We only enforce for USDC transfer() calls.
+     */
+    function checkTransaction(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation,
+        uint256,
+        uint256,
+        uint256,
+        address,
+        address payable,
+        bytes memory,
+        address
+    ) external view override {
+        // If configured to a specific Safe, only allow calls from that Safe.
+        if (safe != address(0) && msg.sender != safe) revert NotSafe();
+
+        // Only guard ERC20 calls.
+        if (to != usdc) return;
+        if (operation != Enum.Operation.Call) return;
+
+        // No ETH value should be sent to ERC20 transfer.
+        (value);
+
+        if (data.length < 4) return;
+        bytes4 sel;
+        assembly {
+            sel := mload(add(data, 0x20))
+        }
+        if (sel != TRANSFER_SELECTOR) return;
+
+        // Decode transfer(address,uint256)
+        (address recipient,) = abi.decode(data[4:], (address, uint256));
+
+        if (recipient != expectedRecipient) {
+            revert RecipientMismatch(expectedRecipient, recipient);
+        }
+    }
+
+    function checkAfterExecution(bytes32, bool) external pure override {}
+}

--- a/packages/contracts/src/RecipientInvariantGuard.sol
+++ b/packages/contracts/src/RecipientInvariantGuard.sol
@@ -90,12 +90,15 @@ contract RecipientInvariantGuard is BaseTransactionGuard {
         }
         if (sel != TRANSFER_SELECTOR) return;
 
-        // Decode transfer(address,uint256)
-        (address recipient,) = abi.decode(data[4:], (address, uint256));
-
-        if (recipient != expectedRecipient) {
-            revert RecipientMismatch(expectedRecipient, recipient);
+        // Decode transfer(address,uint256) without slicing (more portable for Foundry/Solc)
+        address recipient;
+        assembly {
+            // data layout: 0x00 length, 0x20 selector+arg1 (first 32 bytes), 0x40 arg2
+            // recipient is first argument, right-aligned in the 32-byte word at data+0x24
+            recipient := shr(96, mload(add(data, 0x24)))
         }
+
+        if (recipient != expectedRecipient) revert RecipientMismatch(expectedRecipient, recipient);
     }
 
     function checkAfterExecution(bytes32, bool) external pure override {}

--- a/scripts/ens-demo.ts
+++ b/scripts/ens-demo.ts
@@ -2,7 +2,7 @@
 
 /**
  * ENS Integration Demo for ENS Prize
- * 
+ *
  * Demonstrates ZeroKey's ENS-aware security features:
  * 1) ENS name resolution for human-readable addresses
  * 2) ENS-based trust scoring (addresses with ENS get higher trust)
@@ -91,14 +91,14 @@ async function main() {
   console.log("└────────────────────────────────────────────────────────────┘\n");
 
   const ensNames = ["vitalik.eth", "nick.eth", "brantly.eth"];
-  
+
   for (const name of ensNames) {
     const address = resolveEns(name);
     if (address) {
       console.log(`  ${name.padEnd(20)} → ${address}`);
     }
   }
-  
+
   console.log("\n  → Agent says: 'Pay vitalik.eth 0.03 USDC'");
   console.log("  → ZeroKey resolves to: 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
 
@@ -136,7 +136,7 @@ async function main() {
     config: { type: "ens_required", requireEns: true },
     enabled: true,
   });
-  
+
   const policyId = policyRes.json?.id;
   if (policyRes.status === 200 || policyRes.status === 201) {
     console.log("  ✓ Policy active: Recipients must have ENS names\n");
@@ -145,7 +145,7 @@ async function main() {
   // Test 1: Non-ENS recipient (should be REJECTED)
   console.log("  Step 2: Agent tries to pay NON-ENS address");
   console.log(`    To: ${randomAddress} (no ENS)`);
-  
+
   const fwCheck1 = await postJson("/api/firewall/check", {
     from: vitalikAddress,
     to: randomAddress,
@@ -172,7 +172,7 @@ async function main() {
   // Test 2: ENS recipient (should be APPROVED)
   console.log("  Step 3: Agent pays ENS-verified address (policy disabled)");
   console.log(`    To: vitalik.eth (${vitalikAddress})`);
-  
+
   const fwCheck2 = await postJson("/api/firewall/check", {
     from: "0x7aD8317e9aB4837AEF734e23d1C62F4938a6D950",
     to: vitalikAddress,

--- a/scripts/swarm-demo.ts
+++ b/scripts/swarm-demo.ts
@@ -321,7 +321,7 @@ async function main() {
   // Test: Non-ENS recipient should be REJECTED
   console.log("  Step 2: Agent tries to pay non-ENS address");
   console.log("    To: 0x0000000000000000000000000000000000000001 (no ENS)");
-  
+
   const ensCheck1 = await postJson("/api/firewall/check", {
     from: account.address,
     to: "0x0000000000000000000000000000000000000001",
@@ -340,7 +340,7 @@ async function main() {
   // Test: ENS recipient should be APPROVED (without ENS policy)
   console.log("  Step 3: Agent pays ENS-verified recipient (policy disabled)");
   console.log("    To: vitalik.eth (0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045)");
-  
+
   const ensCheck2 = await postJson("/api/firewall/check", {
     from: account.address,
     to: ENS_REGISTRY["vitalik.eth"],


### PR DESCRIPTION
Adds a minimal Safe Guard that reverts on USDC recipient substitution (wallet-enforced).\n\n- New contract: RecipientInvariantGuard.sol\n- Deploy script: DeployRecipientInvariantGuard.s.sol\n- Make target: make guard-demo\n- Doc: docs/GUARD_DEMO.md\n\nGoal: produce a 60s demo with an on-chain revert proof (expected vs got) + success txHash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RecipientInvariantGuard to enforce USDC transfer recipient restrictions.

* **Documentation**
  * Added a Guard Demo doc with setup, deployment, and verification steps for the wallet-enforced guard.

* **Chores**
  * Added `guard-demo` make target to automate guard deployment.
  * Updated demo scripts to improve ENS test payload (adds ENS label) and minor formatting tweaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->